### PR TITLE
Improved UX of registration

### DIFF
--- a/gem/static/css/style.scss
+++ b/gem/static/css/style.scss
@@ -212,6 +212,20 @@ a, a:hover {
   }
 }
 
+
+.signin-form input[type="checkbox"] {
+  padding: 5px;
+}
+
+.terms-and-conditions label {
+  color: #ed008c !important;
+  text-decoration: underline;
+}
+
+.signin-form #id_password {
+  margin: 0;
+}
+
 .signin-form #id_gender {
   text-transform: capitalize;
   margin: 0;
@@ -219,7 +233,7 @@ a, a:hover {
 
 .sigin-form__input-hint {
   text-align: center !important;
-  color: #555 !important;
+  color: #777 !important;
 }
 
 .section_page {

--- a/gem/static/css/style.scss
+++ b/gem/static/css/style.scss
@@ -66,7 +66,7 @@ button, input[type=submit], .button, .gem-polls a {
 }
 
 a, a:hover {
-  color: #7A7A7A;
+  color: #00b8ae;
   text-decoration: none;
 }
 

--- a/gem/templates/profiles/register.html
+++ b/gem/templates/profiles/register.html
@@ -18,11 +18,14 @@
 
             <p><strong>{% trans "Choose a 4-digit pin" %}</strong></p>
             {{ form.password.errors}}
-            {{ form.password }}
+            <input id="id_password" maxlength="4" name="password" type="password" required="" pattern="[0-9]*" inputmode="numeric">
+
+            <p class="sigin-form__input-hint">({% trans "E.g.: 2086" %})</p>
 
             {% if settings.profiles.UserProfilesSettings.show_mobile_number_field %}
             <p><strong>{% trans "Enter your mobile number" %}</strong></p>
             {{ from.errors}}
+
             {{ form.mobile_number }}
             <br>
             {% endif %}
@@ -45,10 +48,12 @@
 
             <br>
             {% if form.terms_and_conditions.errors %}
-              <p>{% trans "Please accept the T&amp;Cs in order to complete the registration" %}</p>
+              <p class="alert-error">{% trans "Please accept the T&amp;Cs in order to complete the registration" %}</p>
             {% endif %}
-            {{ form.terms_and_conditions }}
-            <span>{% trans "I accept the Terms and Conditions" %}</span>
+            <div class="terms-and-conditions">
+              {{ form.terms_and_conditions }}
+              <label for="id_terms_and_conditions">{% trans "I accept the Terms and Conditions" %}</label>
+            </div>
             <br>
             <input type="submit" class="registerSubmit" value='{% trans "JOIN" %}' />
             <input type="hidden" name="next" value="{% url 'molo.profiles:registration_done' %}" />

--- a/gem/templates/registration/login.html
+++ b/gem/templates/registration/login.html
@@ -9,8 +9,8 @@
 
         <div class="block turq">
             <div class="signin-form">
-                <p>{% trans "LOGIN TO YOUR ACCOUNT!" %}</p>
-                <p>{% trans "We’re excited to have you..." %}</p>
+                <p><a href="{% url 'molo.profiles:user_register' %}">{% trans "Not a member yet" %}?</a></p>
+
             <form method="post" action=".">{% csrf_token %}
                 {% if form.errors %}
                     <p class="error errorlist">{% trans "Your username and password does not match. Please try again." %}</p>
@@ -21,7 +21,7 @@
                         {{form.password}}
                         <input type="submit" value="{% trans 'Sign in' %}">
                         <input type="hidden" name="next" value="{% if request.GET.next %}{{ request.GET.next }}{% else %}{{request.site.root_page.url}}{% endif %}" />
-                        <a href="{% url 'molo.profiles:user_register' %}" class="button inverted">{% trans "Not a member yet" %}</a>
+
                         <a href="{% url 'forgot_password' %}" class="button inverted">{% trans "Forgot PIN" %}</a>
             </form>
             </div>


### PR DESCRIPTION
@Mitso Can I get a +1?

Better error message, label is tappable, and looks like a link for checkbox.
![screen shot 2016-06-13 at 15 18 16](https://cloud.githubusercontent.com/assets/44849/16008901/a15ca690-317a-11e6-8085-42ac6a5eb741.png)

Example of a PIN:
![screen shot 2016-06-13 at 15 13 57](https://cloud.githubusercontent.com/assets/44849/16008928/b38a04e8-317a-11e6-9199-fa52dede30e1.png)
