### PR TITLE
remove competition thank you text

### DIFF
--- a/gem/templates/malawi/yourwords/thank_you.html
+++ b/gem/templates/malawi/yourwords/thank_you.html
@@ -8,7 +8,7 @@
     </div>
 
     <h3>{% trans 'Thank you!' %}</h3>
-    <p>{% trans 'Thanks for submitting your story! You’ll find out soon if you’re a winner!' %}</p>
+    <p>{% trans 'Thanks for submitting your story!' %}</p>
 
     <div>
       <a href="{{ request.site.root_page.url }}" class="button">{% trans "HOME" %}</a>


### PR DESCRIPTION
@Mitso please review

Removal of the second thank you line "You’ll find out soon if you’re a winner!"

Before
<img width="419" alt="screen shot 2017-04-18 at 12 29 24 pm" src="https://cloud.githubusercontent.com/assets/9653693/25133807/1fb9b7e6-244e-11e7-9cfa-0511dd2a7e28.png">

After
![your_word_thanks](https://cloud.githubusercontent.com/assets/9653693/25134015/b48351d4-244e-11e7-88da-addfbda5af07.png)
