### PR TITLE
Carousel image fill

### DIFF
--- a/gem/templates/springster/patterns/basics/article-teasers/sp_variations/carousel-teaser-image.html
+++ b/gem/templates/springster/patterns/basics/article-teasers/sp_variations/carousel-teaser-image.html
@@ -1,0 +1,7 @@
+{% load wagtailcore_tags core_tags wagtailimages_tags %}
+{% if article.image %}
+<a href="{% pageurl article %}" class="carousel-teaser__thumbnail-link">
+  {% image article.image fill-168x96 as carousel_teaser_thumbnail %}
+  <img src="{{ carousel_teaser_thumbnail.url }}" class="carousel-teaser__thumbnail" />
+</a>
+{% endif %}


### PR DESCRIPTION
Carousel Images needs to fill 168x96 container

`fill-168x96` 

previously deleted pattern recovered

<img width="440" alt="screen shot 2017-05-23 at 4 51 30 pm" src="https://cloud.githubusercontent.com/assets/9653693/26360318/19a46798-3fd8-11e7-9755-2b92c863b336.png">
<img width="449" alt="screen shot 2017-05-23 at 4 51 22 pm" src="https://cloud.githubusercontent.com/assets/9653693/26360320/1a0c1ab4-3fd8-11e7-8989-13732f9683e1.png">


