### PR TITLE
fix reaction Q template

### DIFF
--- a/gem/templates/springster/patterns/basics/articles/reaction_question.html
+++ b/gem/templates/springster/patterns/basics/articles/reaction_question.html
@@ -3,11 +3,8 @@
 {% if question %}
 <div class="reaction-questions__block">
   {% include "patterns/basics/headings/sp_variations/heading.html" with type="subheading" htmltag="h3" title=question.title %}
-  <div class="errors">
-    {{ form.errors }}
     {% load_user_can_vote_on_reaction_question question article.pk as user_can_vote%}
       {% if user_can_vote %}
-        </div>
         <form class="reaction-questions__form" action="{% url 'reaction-vote' article.slug question.id %}" method="post">
           {% csrf_token %}
           <div class="reaction-questions__list">
@@ -27,8 +24,12 @@
               {% endfor %}
           </div>
         </form>
-      </div>
+      
       {% else %}
+      <div class="errors">
+        {{ form.errors }}
         {% trans "You have already submitted a response for this article." %}
+      </div>  
       {% endif %}
+  </div>
 {% endif %}


### PR DESCRIPTION
error message messed up the page layout 

Before
<img width="466" alt="screen shot 2017-06-09 at 2 34 24 pm" src="https://user-images.githubusercontent.com/9653693/26975625-d661ad14-4d20-11e7-807f-f9ade76c026c.png">

Fixed:
<img width="476" alt="screen shot 2017-06-09 at 2 34 00 pm" src="https://user-images.githubusercontent.com/9653693/26975626-d6bde444-4d20-11e7-92b6-9413a05b4c86.png">
