### PR TITLE
Ensure SECRET_KEY is set correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ jobs:
         - molo_version="$(sed -nE 's/^molo\.core==(.*)$/\1/p' requirements.txt)"
         - docker pull "$IMAGE_NAME" || true
       script:
-        - docker build --pull --tag "$IMAGE_NAME" --build-arg MOLO_VERSION="$molo_version" .
+        - docker build --pull --tag "$IMAGE_NAME" --build-arg MOLO_VERSION="$molo_version" SECRET_KEY="docker-build-key" .
 
       before_deploy:
         - pip install docker-ci-deploy==0.3.0

--- a/gem/settings/docker.py
+++ b/gem/settings/docker.py
@@ -1,5 +1,6 @@
 """Django settings for use within the docker container."""
 
+from django.core.exceptions import ImproperlyConfigured
 from os import environ
 
 import dj_database_url
@@ -11,7 +12,12 @@ from .production import *
 
 DEBUG = False
 
-SECRET_KEY = environ.get('SECRET_KEY') or 'please-change-me'
+default_secret_key = 'please-change-me'
+SECRET_KEY = environ.get('SECRET_KEY') or default_secret_key
+
+if SECRET_KEY == default_secret_key:
+    raise ImproperlyConfigured('Secure SECRET_KEY not provided')
+
 PROJECT_ROOT = (
     environ.get('PROJECT_ROOT') or dirname(dirname(abspath(__file__))))
 


### PR DESCRIPTION
While looking through the codebase for the first time this setting worried me a little bit. In my experience it's very easy to forget to set this environment variable, which will cause the SECRET_KEY to be disclosed.

This commit means the app refuses to start unless the SECRET_KEY is set correctly. This will break currently running applications if they are upgraded to include this commit.