### PR TITLE
Upgrade molo.surveys to 6.1.0

### DIFF
--- a/gem/settings/base.py
+++ b/gem/settings/base.py
@@ -495,5 +495,5 @@ SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 AWS_S3_FILE_OVERWRITE = False
 
 PERSONALISATION_SEGMENTS_ADAPTER = (
-    'molo.surveys.adapters.SurveysSegmentsAdapter'
+    'molo.surveys.adapters.PersistentSurveysSegmentsAdapter'
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 molo.core==6.1.0
 molo.commenting==6.0.0
-molo.surveys==6.0.0
+molo.surveys==6.1.0
 molo.pwa==6.0.0
 molo.servicedirectory==6.0.1
 molo.yourwords==6.0.0


### PR DESCRIPTION
This uses the new persistent segments adapter to ensure that we're storing pageview data for personalisable surveys.