### PR TITLE
Remove UNICORE_DISTRIBUTE_API from settings

### DIFF
--- a/gem/settings/base.py
+++ b/gem/settings/base.py
@@ -383,8 +383,6 @@ REGEX_EMAIL = r'([\w\.-]+@[\w\.-]+)'
 
 ADMIN_LANGUAGE_CODE = environ.get('ADMIN_LANGUAGE_CODE', "en")
 
-UNICORE_DISTRIBUTE_API = environ.get(
-    'UNICORE_DISTRIBUTE_API', 'http://localhost:6543')
 FROM_EMAIL = environ.get('FROM_EMAIL', "support@moloproject.org")
 CONTENT_IMPORT_SUBJECT = environ.get(
     'CONTENT_IMPORT_SUBJECT', 'Molo Content Import')


### PR DESCRIPTION
This stopped being used in praekelt/molo@11457e0fa578f09e7e8a4fd0f1595b4e47ab109c