### PR TITLE
Change the session age to 2 hours

### DIFF
--- a/gem/settings/base.py
+++ b/gem/settings/base.py
@@ -169,9 +169,9 @@ ROOT_URLCONF = 'gem.urls'
 WSGI_APPLICATION = 'gem.wsgi.application'
 
 # GEM-195
-# Automatically log users out after 10 mins of inactivity
+# Automatically log users out after 2 hours of inactivity
 # Closing the browser window/tab will NOT end the session
-SESSION_COOKIE_AGE = 60 * 10  # 10 minutes
+SESSION_COOKIE_AGE = 60 * 120  # 2Hours
 SESSION_SAVE_EVERY_REQUEST = True
 
 # Database


### PR DESCRIPTION
At the moment if the admin users are editing or creating pages in CMS and they don't save the page before 10 Min it will automatically log them out, and they will lose all the data.

hopefully increasing it to 2 hours will solve this problem :) 