### PR TITLE
Remove unused forms from context processors

### DIFF
--- a/gem/context_processors.py
+++ b/gem/context_processors.py
@@ -1,11 +1,8 @@
-from molo.profiles.forms import RegistrationForm
-from molo.profiles.forms import EditProfileForm, ProfilePasswordChangeForm
+from molo.profiles.forms import ProfilePasswordChangeForm
 
 
 def default_forms(request):
     return {
-        'registration_form': RegistrationForm(),
-        'edit_profile_form': EditProfileForm(),
         'password_change_form': ProfilePasswordChangeForm()
     }
 


### PR DESCRIPTION
These forms are not used by any view or template. On every request Django is generating the entire HTML form for these 2 forms which is a whole load of unnecessary CPU.