### PR TITLE
Bump molo.commenting to 6.2.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 molo.core==6.3.1
-molo.commenting==6.2.1
+molo.commenting==6.2.2
 molo.surveys==6.3.2
 molo.pwa==6.1.0
 molo.servicedirectory==6.1.0


### PR DESCRIPTION
Fixes an error with unicode comments.