### PR TITLE
Add migration for security questions

### DIFF
--- a/gem/management/commands/create_security_questions_from_settings.py
+++ b/gem/management/commands/create_security_questions_from_settings.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import logging
+
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+from django.core.management.base import BaseCommand
+from django.utils.translation import activate, ugettext
+
+from molo.core.models import Languages, Main, PageTranslation
+from molo.profiles.models import SecurityQuestionIndexPage, SecurityQuestion
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        for question_number in range(1, 3):
+            setting = 'SECURITY_QUESTION_{0}'.format(question_number)
+            english_question_text = getattr(settings, setting, None)
+
+            if english_question_text is None:
+                raise ImproperlyConfigured(
+                    'Security question {0} is unset'.format(setting))
+
+            for main_page in Main.objects.all():
+                security_index = SecurityQuestionIndexPage.objects.child_of(
+                    main_page).first()
+
+                site = main_page.get_site()
+
+                main_language = Languages.for_site(site).languages.filter(
+                    is_active=True, is_main_language=True,
+                ).first()
+                other_languages = Languages.for_site(site).languages.filter(
+                    is_active=True, is_main_language=False,
+                ).all()
+
+                if main_language is None:
+                    logging.info(
+                        'Main language unset, not creating security questions')
+                    continue
+
+                activate(main_language.locale)
+                question_text_main_language = ugettext(english_question_text)
+
+                question = SecurityQuestion(title=question_text_main_language)
+                security_index.add_child(instance=question)
+                question.save_revision().publish()
+
+                for language in other_languages:
+                    activate(language.locale)
+                    question_text_localised = ugettext(english_question_text)
+
+                    question_localised = SecurityQuestion(
+                        title=question_text_localised)
+                    security_index.add_child(instance=question_localised)
+
+                    question_language = question_localised.languages.first()
+                    question_language.language = language
+                    question_language.save()
+
+                    question_localised.save_revision().publish()
+
+                    PageTranslation.objects.get_or_create(
+                        page=question,
+                        translated_page=question_localised,
+                    )

--- a/gem/migrations/0024_create_security_questions.py
+++ b/gem/migrations/0024_create_security_questions.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.core.management import call_command
+from django.db import migrations
+
+
+def create_security_questions(apps, schema_editor):
+    call_command('create_security_questions_from_settings')
+
+
+def delete_security_questions(apps, schema_editor):
+    # It's difficult to know which questions we should be deleting
+    # from the database. The questions may not be in the settings anymore.
+    # It's much safer to just do a no-op here and there aren't really
+    # any downsides. Questions can be modified in Wagtail admin.
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('gem', '0023_move_migrated_user_name_to_molo_profiles'),
+        ('profiles', '0018_userprofile_admin_sites'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            create_security_questions,
+            delete_security_questions,
+        ),
+    ]

--- a/gem/tests/test_management_commands.py
+++ b/gem/tests/test_management_commands.py
@@ -1,10 +1,12 @@
 # -*- coding: UTF-8 -*-
+from __future__ import unicode_literals
+
 from django.contrib.sites.models import Site
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django_comments.models import Comment
 from django.core.management import call_command
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.utils import timezone
 from django.utils.six import StringIO
 from wagtail.wagtailimages.tests.utils import Image, get_test_image_file
@@ -13,6 +15,7 @@ from molo.core.tests.base import MoloTestCaseMixin
 from molo.core.models import (SiteLanguageRelation, Main, Languages,
                               ReactionQuestion, ReactionQuestionChoice,
                               ArticlePage, BannerPage)
+from molo.profiles.models import SecurityQuestion
 
 
 class GemManagementCommandsTest(TestCase, MoloTestCaseMixin):
@@ -400,3 +403,70 @@ class GemManagementCommandsTest(TestCase, MoloTestCaseMixin):
 
         for comment in Comment.objects.all().iterator():
             self.assertNotIn(comment.comment, 'Type your comment here...')
+
+
+@override_settings(
+    SECURITY_QUESTION_1='Answer to Security Question 1',
+    SECURITY_QUESTION_2='Answer to Security Question 2',
+)
+class CreateSecurityQuestionsFromSettingsTest(TestCase, MoloTestCaseMixin):
+    def setUp(self):
+        self.mk_main()
+        self.main = Main.objects.all().first()
+
+        self.language_setting = Languages.objects.create(
+            site_id=self.main.get_site().pk)
+
+        SiteLanguageRelation.objects.create(
+            language_setting=self.language_setting,
+            locale='en',
+            is_active=True)
+
+    def test_it_creates_main_language_questions_for_one_site(self):
+        call_command('create_security_questions_from_settings')
+
+        questions = SecurityQuestion.objects.all()
+        self.assertEqual(questions.count(), 2)
+        self.assertEqual(
+            questions.first().title,
+            'Answer to Security Question 1',
+        )
+        self.assertEqual(
+            questions.last().title,
+            'Answer to Security Question 2',
+        )
+
+    def test_it_creates_translations_for_one_site(self):
+        SiteLanguageRelation.objects.create(
+            language_setting=self.language_setting,
+            locale='fr',
+            is_active=True)
+
+        call_command('create_security_questions_from_settings')
+
+        questions = SecurityQuestion.objects.all()
+
+        self.assertEqual(questions.count(), 4)
+
+        # FIXME: It would be nice to assert the translation of the question
+        # is correct but there's something up with the locales available on
+        # Travis which makes the translation not work.
+
+    def test_it_creates_questions_for_multiple_sites(self):
+        self.mk_main2()
+        self.main2 = Main.objects.all().last()
+
+        self.language_setting2 = Languages.objects.create(
+            site_id=self.main2.get_site().pk)
+
+        SiteLanguageRelation.objects.create(
+            language_setting=self.language_setting2,
+            locale='rw',
+            is_active=True)
+
+        call_command('create_security_questions_from_settings')
+
+        questions = SecurityQuestion.objects.all()
+        self.assertEqual(questions.count(), 4)
+        self.assertEqual(questions.descendant_of(self.main).count(), 2)
+        self.assertEqual(questions.descendant_of(self.main2).count(), 2)


### PR DESCRIPTION
This commit creates security questions for each of the settings.

It applies to each of the sites in a multi-site setup and creates translations in each language on the site.

I haven't written any tests for this and I don't know if I should. It feels kind of tricky to write tests for a migration like this.