### PR TITLE
Add rules to segment admin

### DIFF
--- a/gem/admin.py
+++ b/gem/admin.py
@@ -13,6 +13,7 @@ from django.db.models import Q
 from django.shortcuts import redirect
 from django.utils.translation import ugettext_lazy as _
 from gem.models import GemUserProfile, GemCommentReport
+from gem.rules import ProfileDataRule, CommentCountRule
 from gem.tasks import send_export_email_gem
 
 from import_export.fields import Field
@@ -310,6 +311,22 @@ class GemCommentModelAdmin(MoloCommentsModelAdmin):
 
 class GemCommentReportAdmin(MoloCommentAdmin):
     inlines = (GemCommentReportModelAdmin,)
+
+
+class ProfileDataRuleAdminInline(admin.TabularInline):
+    """
+    Inline the ProfileDataRule into the administration
+    interface for segments.
+    """
+    model = ProfileDataRule
+
+
+class CommentCountRuleAdminInline(admin.TabularInline):
+    """
+    Inline the CommentCountRule into the administration
+    interface for segments.
+    """
+    model = CommentCountRule
 
 
 admin.site.unregister(User)


### PR DESCRIPTION
wagtail_personalisation uses `AbstractBaseRule.__subclasses__()` to discover which rules to show in the interface which is incredibly confusing.

It's not strictly necessary to inline the rules in the admin, they only needed to be imported here so that Python is aware that they exist. However I think it's more explicit and is what wagtail_personalisation does in `admin.py` (even though that only contains a subset of their rules, the others are loaded because they are subclasses of AbstractBaseRule.

I'm unable to write a meaningful test for this because for some reason the test is already loading `gem.rules`, so the test passes even without this code change.

Note `gem.rules` available here even before this code change was made:

```
> /Users/alexmuller/praekelt/molo-gem/gem/tests/test_admin.py(209)test_profile_data_rule_is_available_in_admin()
-> response = self.client.get(self.segment_create)
(Pdb) from wagtail_personalisation.rules import AbstractBaseRule
(Pdb) AbstractBaseRule.__subclasses__()
[<class 'gem.rules.ProfileDataRule'>, <class 'wagtail_personalisation.rules.TimeRule'>, <class 'wagtail_personalisation.rules.DayRule'>, <class 'wagtail_personalisation.rules.ReferralRule'>, <class 'wagtail_personalisation.rules.VisitCountRule'>, <class 'molo.surveys.rules.ArticleTagRule'>, <class 'wagtail_personalisation.rules.QueryRule'>, <class 'wagtail_personalisation.rules.DeviceRule'>, <class 'wagtail_personalisation.rules.UserIsLoggedInRule'>, <class 'molo.commenting.rules.CommentDataRule'>, <class 'molo.surveys.rules.SurveySubmissionDataRule'>, <class 'molo.surveys.rules.SurveyResponseRule'>, <class 'molo.surveys.rules.GroupMembershipRule'>, <class 'molo.surveys.rules.CombinationRule'>, <class 'gem.rules.CommentCountRule'>]
```

[Difference between test and app output](https://gist.github.com/alexmuller/cd0be6d3859fb2ecc911e0ce9bb2c331) - note that the test output already contains `Profile Data Rule (Static compatible)` and `Comment count rule (Static compatible)` even before this code change.

Test that already passes:

```
def test(self):
    self.mk_main()
    self.login()
    response = self.client.get('/admin/wagtail_personalisation/segment/create/')
    self.assertContains(response, 'profile data rule (static compatible)')
```