### PR TITLE
Add migration to copy security answers to molo.profiles

### DIFF
--- a/gem/management/commands/migrate_security_answers_to_molo_profiles.py
+++ b/gem/management/commands/migrate_security_answers_to_molo_profiles.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import logging
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ImproperlyConfigured
+from django.core.management.base import BaseCommand
+
+from molo.profiles.models import (
+    SecurityAnswer,
+    SecurityQuestion,
+    SecurityQuestionIndexPage,
+)
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        for question_number in range(1, 3):
+            question_setting = 'SECURITY_QUESTION_{0}'.format(question_number)
+            question_text = getattr(settings, question_setting, None)
+
+            if question_text is None:
+                raise ImproperlyConfigured(
+                    'Security question {0} is unset'.format(question_setting))
+
+            logging.info('Migrating answers for {0}'.format(question_setting))
+
+            for user in get_user_model().objects.all():
+                if not hasattr(user, 'profile'):
+                    logging.warn('User {0} has no profile'.format(user.id))
+                    continue
+
+                main_page = user.profile.site.root_page
+                security_index = SecurityQuestionIndexPage.objects.child_of(
+                    main_page).first()
+
+                question = SecurityQuestion.objects.filter(
+                    title=question_text).child_of(security_index).first()
+
+                if not question:
+                    logging.warn('Unable to migrate "{0}" for {1}'.format(
+                        question_text, user.id))
+                    continue
+
+                answer_hashes = [
+                    user.gem_profile.security_question_1_answer,
+                    user.gem_profile.security_question_2_answer,
+                ]
+
+                answer_hash = answer_hashes[question_number-1]
+
+                if answer_hash is None or len(answer_hash) == 0:
+                    logging.warn('User {0} has empty hash for {1}'.format(
+                        user.id,
+                        question_setting,
+                    ))
+                    continue
+
+                security_answer, _ = SecurityAnswer.objects.get_or_create(
+                    question=question,
+                    user=user.profile,
+                )
+                security_answer.answer = answer_hash
+                security_answer.save(is_import=True)

--- a/gem/migrations/0026_migrate_security_answers_off_gem_profile.py
+++ b/gem/migrations/0026_migrate_security_answers_off_gem_profile.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.core.management import call_command
+from django.db import migrations
+
+
+def migrate_security_answers(apps, schema_editor):
+    call_command('migrate_security_answers_to_molo_profiles')
+
+
+def unmigrate_security_answers(apps, schema_editor):
+    # We probably shouldn't delete everybody's security answers
+    # as part of the reverse migration. The questions might not
+    # be in the settings anymore.
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('gem', '0025_move_gender_to_molo_profiles'),
+        ('profiles', '0018_userprofile_admin_sites'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            migrate_security_answers,
+            unmigrate_security_answers,
+        ),
+    ]

--- a/gem/tests/test_management_commands.py
+++ b/gem/tests/test_management_commands.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 from django.contrib.sites.models import Site
+from django.contrib.auth import get_user_model
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django_comments.models import Comment
@@ -15,7 +16,11 @@ from molo.core.tests.base import MoloTestCaseMixin
 from molo.core.models import (SiteLanguageRelation, Main, Languages,
                               ReactionQuestion, ReactionQuestionChoice,
                               ArticlePage, BannerPage)
-from molo.profiles.models import SecurityQuestion
+from molo.profiles.models import (
+    SecurityAnswer,
+    SecurityQuestion,
+    SecurityQuestionIndexPage,
+)
 
 
 class GemManagementCommandsTest(TestCase, MoloTestCaseMixin):
@@ -484,3 +489,87 @@ class CreateSecurityQuestionsFromSettingsTest(TestCase, MoloTestCaseMixin):
         self.assertEqual(questions.count(), 4)
         self.assertEqual(questions.descendant_of(self.main).count(), 2)
         self.assertEqual(questions.descendant_of(self.main2).count(), 2)
+
+
+@override_settings(
+    SECURITY_QUESTION_1='Question 1',
+    SECURITY_QUESTION_2='Question 2',
+)
+class MigrateSecurityAnswersToMoloProfilesTest(TestCase, MoloTestCaseMixin):
+    def setUp(self):
+        self.mk_main()
+        main = Main.objects.first()
+
+        security_index = SecurityQuestionIndexPage.objects.child_of(
+            main).first()
+
+        self.questions = []
+
+        for i in range(1, 3):
+            question = SecurityQuestion(title='Question {0}'.format(i))
+            security_index.add_child(instance=question)
+            question.save_revision().publish()
+            self.questions.append(question)
+
+        self.user = get_user_model().objects.create(username='user')
+        self.user.save()
+
+        self.user.gem_profile.set_security_question_1_answer('Answer 1')
+        self.user.gem_profile.set_security_question_2_answer('Answer 2')
+        self.user.gem_profile.save()
+
+    def test_it_copies_security_answers_to_molo_profiles(self):
+        call_command('migrate_security_answers_to_molo_profiles')
+
+        security_answer_1 = SecurityAnswer.objects.get(
+            question=self.questions[0],
+            user=self.user.profile,
+        )
+
+        security_answer_2 = SecurityAnswer.objects.get(
+            question=self.questions[1],
+            user=self.user.profile,
+        )
+
+        self.assertTrue(security_answer_1.check_answer('Answer 1'))
+        self.assertTrue(security_answer_2.check_answer('Answer 2'))
+
+    def test_it_copies_answers_for_multiple_sites(self):
+        self.mk_main2()
+        main2 = Main.objects.last()
+
+        security_index2 = SecurityQuestionIndexPage.objects.child_of(
+            main2).first()
+
+        questions2 = []
+
+        for i in range(1, 3):
+            question = SecurityQuestion(title='Question {0}'.format(i))
+            security_index2.add_child(instance=question)
+            question.save_revision().publish()
+            questions2.append(question)
+
+        user2 = get_user_model().objects.create(username='user2')
+        user2.save()
+
+        user2.profile.site = main2.get_site()
+        user2.profile.save()
+
+        user2.gem_profile.set_security_question_1_answer('User 2 Answer 1')
+        user2.gem_profile.set_security_question_2_answer('User 2 Answer 2')
+        user2.gem_profile.save()
+
+        call_command('migrate_security_answers_to_molo_profiles')
+
+        security_answer_1 = SecurityAnswer.objects.get(
+            question=questions2[0],
+            user=user2.profile,
+        )
+
+        security_answer_2 = SecurityAnswer.objects.get(
+            question=questions2[1],
+            user=user2.profile,
+        )
+
+        self.assertTrue(security_answer_1.check_answer('User 2 Answer 1'))
+        self.assertTrue(security_answer_2.check_answer('User 2 Answer 2'))


### PR DESCRIPTION
Now that the security answers are being written to both gem and molo profiles we can copy old answers to molo.profiles.

Once they've been copied we can read from the molo profile.