### PR TITLE
Migrate security answers: continue if user profile has no site

### DIFF
--- a/gem/management/commands/migrate_security_answers_to_molo_profiles.py
+++ b/gem/management/commands/migrate_security_answers_to_molo_profiles.py
@@ -32,6 +32,10 @@ class Command(BaseCommand):
                     logging.warn('User {0} has no profile'.format(user.id))
                     continue
 
+                if user.profile.site is None:
+                    logging.warn('User {0} has no site'.format(user.id))
+                    continue
+
                 main_page = user.profile.site.root_page
                 security_index = SecurityQuestionIndexPage.objects.child_of(
                     main_page).first()


### PR DESCRIPTION
Sometimes a user's profile has no site.

```
'NoneType' object has no attribute 'root_page'
```