### PR TITLE
Improve context processors

### DIFF
--- a/gem/context_processors.py
+++ b/gem/context_processors.py
@@ -1,17 +1,5 @@
 from django.conf import settings
 
-from molo.profiles.forms import ProfilePasswordChangeForm
-
-
-# TODO: this context processor generates the HTML for the password
-# change form on every single request which is hugely inefficient.
-# Once password_change_form is available for the viewprofile.html
-# view we can remove this context processor.
-def default_forms(request):
-    return {
-        'password_change_form': ProfilePasswordChangeForm()
-    }
-
 
 # TODO: remove this context processor
 def detect_freebasics(request):

--- a/gem/context_processors.py
+++ b/gem/context_processors.py
@@ -1,7 +1,6 @@
 from django.conf import settings
 
 
-# TODO: remove this context processor
 def detect_freebasics(request):
     return {
         'is_via_freebasics':

--- a/gem/settings/base.py
+++ b/gem/settings/base.py
@@ -151,7 +151,6 @@ DEFAULT_TEMPLATE = {
             'django.contrib.messages.context_processors.messages',
             'molo.core.context_processors.locale',
             'wagtail.contrib.settings.context_processors.settings',
-            'gem.context_processors.default_forms',
             'gem.context_processors.detect_freebasics',
             'gem.context_processors.compress_settings',
         ],

--- a/gem/templates/springster/core/tags/bannerpages.html
+++ b/gem/templates/springster/core/tags/bannerpages.html
@@ -1,6 +1,5 @@
 {% load gem_tags %}
  {% if bannerpages %}
- {% is_via_freebasics as is_via_freebasics %}
    {% for bannerpage in bannerpages %}
    {% if bannerpage.hide_on_freebasics %}
      {% if not is_via_freebasics %}

--- a/gem/templatetags/gem_tags.py
+++ b/gem/templatetags/gem_tags.py
@@ -24,14 +24,6 @@ def gender_display(gender):
     return None
 
 
-@register.simple_tag(takes_context=True)
-def is_via_freebasics(context):
-    request = context['request']
-    return ('Internet.org' in request.META.get('HTTP_VIA', '') or
-            'InternetOrgApp' in request.META.get('HTTP_USER_AGENT', '') or
-            'true' in request.META.get('HTTP_X_IORG_FBS', ''))
-
-
 @register.inclusion_tag('core/tags/bannerpages.html', takes_context=True)
 def gembannerpages(context):
     request = context['request']

--- a/gem/tests/templatetags/test_gem_tags.py
+++ b/gem/tests/templatetags/test_gem_tags.py
@@ -1,32 +1,8 @@
-from django.test import RequestFactory, TestCase
+from django.test import TestCase
 
 from gem.templatetags.gem_tags import (
-    is_via_freebasics,
     smart_truncate_chars,
 )
-
-
-class TestIsViaFreebasics(TestCase):
-    def setUp(self):
-        self.request_factory = RequestFactory()
-
-    def test_returns_true_if_internetorg_in_httpvia(self):
-        request = self.request_factory.get('/', HTTP_VIA='Internet.org')
-        context = {'request': request}
-        self.assertTrue(is_via_freebasics(context))
-
-    def test_returns_true_if_internetorgapp_in_user_agent(self):
-        request = self.request_factory.get(
-            '/',
-            HTTP_USER_AGENT='InternetOrgApp',
-        )
-        context = {'request': request}
-        self.assertTrue(is_via_freebasics(context))
-
-    def test_returns_true_if_true_in_xiorgsfbs(self):
-        request = self.request_factory.get('/', HTTP_X_IORG_FBS='true')
-        context = {'request': request}
-        self.assertTrue(is_via_freebasics(context))
 
 
 class TestSmartTruncateChars(TestCase):

--- a/gem/tests/test_context_processors.py
+++ b/gem/tests/test_context_processors.py
@@ -1,0 +1,52 @@
+from django.test import RequestFactory, TestCase, override_settings
+
+from gem.context_processors import compress_settings, detect_freebasics
+
+
+class TestDetectFreebasics(TestCase):
+    def setUp(self):
+        self.request_factory = RequestFactory()
+
+    def test_returns_false_by_default(self):
+        request = self.request_factory.get('/')
+        self.assertEqual(
+            detect_freebasics(request),
+            {'is_via_freebasics': False},
+        )
+
+    def test_returns_true_if_internetorg_in_httpvia(self):
+        request = self.request_factory.get('/', HTTP_VIA='Internet.org')
+        self.assertEqual(
+            detect_freebasics(request),
+            {'is_via_freebasics': True},
+        )
+
+    def test_returns_true_if_internetorgapp_in_user_agent(self):
+        request = self.request_factory.get(
+            '/',
+            HTTP_USER_AGENT='InternetOrgApp',
+        )
+        self.assertEqual(
+            detect_freebasics(request),
+            {'is_via_freebasics': True},
+        )
+
+    def test_returns_true_if_true_in_xiorgsfbs(self):
+        request = self.request_factory.get('/', HTTP_X_IORG_FBS='true')
+        self.assertEqual(
+            detect_freebasics(request),
+            {'is_via_freebasics': True},
+        )
+
+
+class TestCompressSettings(TestCase):
+    @override_settings(ENV='test_env', STATIC_URL='test_static_url')
+    def test_returns_settings(self):
+        request = RequestFactory().get('/')
+        self.assertEqual(
+            compress_settings(request),
+            {
+                'ENV': 'test_env',
+                'STATIC_URL': 'test_static_url',
+            }
+        )


### PR DESCRIPTION
## Remove default_forms context processor

We don't need this anymore, the password change form is available in molo.profiles.

## Keep context processor for freebasics instead of templatetag

I've been thinking about this and I think a context processor is better than a template tag for this. With the tag you have to import and assign the result inside the template, and we use it quite frequently.

With the context processor it's always available and the overhead of checking the request headers doesn't feel huge to me. I think it's probably quite quick.