### PR TITLE
Introduce template fragment caching

### DIFF
--- a/gem/templates/springster/base.html
+++ b/gem/templates/springster/base.html
@@ -1,4 +1,4 @@
-{% load compress wagtailuserbar core_tags staticfiles %}
+{% load cache compress wagtailuserbar core_tags staticfiles %}
 {% load wagtailsettings_tags wagtailimages_tags molo_commenting_tags %}
 {% get_settings %}
 {% get_current_language as LANGUAGE_CODE %}
@@ -95,16 +95,18 @@
   </head>
   <body class="{% block body_class %}{% endblock %}" {% if LANGUAGE_CODE|language_bidi == True %}dir="rtl"{% endif %}>
     {% wagtailuserbar %}
-    <div id="header-wrapper">
-      <div id="language-bar">
-        {% block navigation %}
-          {% include "patterns/basics/languages/sp_variations/language-list-center_fixed.html" %}
+    {% cache 3600 base_header LANGUAGE_CODE %}
+      <div id="header-wrapper">
+        <div id="language-bar">
+          {% block navigation %}
+            {% include "patterns/basics/languages/sp_variations/language-list-center_fixed.html" %}
+          {% endblock %}
+        </div>
+        {% block header %}
+          {% include "patterns/components/header/sp_variations/header-center.html" %}
         {% endblock %}
       </div>
-      {% block header %}
-        {% include "patterns/components/header/sp_variations/header-center.html" %}
-      {% endblock %}
-    </div>
+    {% endcache %}
     <div id="content-wrapper" class="content-wrapper">
       <div class="content">
         {% display_unread_notifications %}
@@ -117,34 +119,36 @@
 
         {% tag_menu_homepage %}
 
-        {% block footer_menu %}
-          {% include "patterns/components/footer/sp_variations/footer-menu.html" %}
-        {% endblock %}
-
-        {% block footer %}
-          {% if 'bbm.' in request.get_host %}
-            {% include "patterns/components/footer/sp_variations/footer.html" with type="bbm_home" %}
-          {% else %}
-            {% include "patterns/components/footer/sp_variations/footer.html" %}
-          {% endif %}
-
-          {% block google_analytics %}
-            {% include "patterns/components/ga_tag_manager.html" %}
+        {% cache 3600 base_footer LANGUAGE_CODE %}
+          {% block footer_menu %}
+            {% include "patterns/components/footer/sp_variations/footer-menu.html" %}
           {% endblock %}
-          {% block facebook_pixel_tracker %}
-            {% include "patterns/components/facebook_pixel_tracker.html" %}
-          {% endblock %}
-          {% block facebook_analytics %}
-            {% include "core/facebook_analytics.html" %}
-          {% endblock %}
-          {% if 'bbm.' in request.get_host %}
-            {% include "patterns/components/bbm_partner_ga_code.html" %}
-          {% endif %}
-        {% endblock %}
 
-        {% block copyright %}
-          {% include "patterns/basics/copyright/copyright-terms.html" %}
-        {% endblock %}
+          {% block footer %}
+            {% if 'bbm.' in request.get_host %}
+              {% include "patterns/components/footer/sp_variations/footer.html" with type="bbm_home" %}
+            {% else %}
+              {% include "patterns/components/footer/sp_variations/footer.html" %}
+            {% endif %}
+
+            {% block google_analytics %}
+              {% include "patterns/components/ga_tag_manager.html" %}
+            {% endblock %}
+            {% block facebook_pixel_tracker %}
+              {% include "patterns/components/facebook_pixel_tracker.html" %}
+            {% endblock %}
+            {% block facebook_analytics %}
+              {% include "core/facebook_analytics.html" %}
+            {% endblock %}
+            {% if 'bbm.' in request.get_host %}
+              {% include "patterns/components/bbm_partner_ga_code.html" %}
+            {% endif %}
+          {% endblock %}
+
+          {% block copyright %}
+            {% include "patterns/basics/copyright/copyright-terms.html" %}
+          {% endblock %}
+        {% endcache %}
       </div>
     </div>
 

--- a/gem/templates/springster/core/main.html
+++ b/gem/templates/springster/core/main.html
@@ -1,8 +1,10 @@
 {% extends "base.html" %}
-{% load core_tags molo_survey_tags poll_votings competition_tag el_pagination_tags media_tags gem_tags %}
+{% load cache core_tags molo_survey_tags poll_votings competition_tag el_pagination_tags media_tags gem_tags %}
 {% block content %}
-  {% bannerpages position=0 %}
-  {% gembannerpages %}
+  {% cache 900 main_banners_top request.site locale_code %}
+    {% bannerpages position=0 %}
+    {% gembannerpages %}
+  {% endcache %}
   {% if not settings.core.SiteSettings.enable_tag_navigation %}
     {% topic_of_the_day %}
     {% latest_listing_homepage num_count=6 %}


### PR DESCRIPTION
It's hard to measure exactly the impact of this because there are currently so many database queries for the homepage. In development I need to remove the final `{% get_pages %}` to get the page to load successfully with the debug toolbar.

- `develop`: 2801 queries in 1537.64ms
- this branch with a warm cache: 1369 queries in 845.82ms

Before merging this I'd like to make sure we have some good content and measurements for QA and then we'll need to test this thoroughly by publishing new content and observing the result.

## Cache header and footer template for 1 hour 

I think these could probably be longer because I doubt they change much but an hour is fine.

This removes about 250 SQL queries from a homepage load.

## Cache homepage banners for 15 minutes

My understanding is that this means new banners could take up to 15 minutes to appear on the homepage.

We could probably make this smarter by removing the cached items when a new banner is published, but for the time being I think this basic approach is fine.