### PR TITLE
Add dev logging

### DIFF
--- a/gem/settings/dev.py
+++ b/gem/settings/dev.py
@@ -15,3 +15,24 @@ try:
     from secrets import *  # noqa
 except ImportError:
     pass
+
+
+LOGGING = {
+    'version': 1,
+    'loggers': {
+        'django': {
+            'level': 'INFO',
+            'handlers': ['console'],
+        },
+        'django.template': {
+            'level': 'DEBUG',
+            'handlers': ['console'],
+        },
+    },
+    'handlers': {
+        'console': {
+            'level': 'DEBUG',
+            'class': 'logging.StreamHandler',
+        }
+    },
+}


### PR DESCRIPTION
There are lots of exceptions from templates so we should make those visible in the development logs.