### PR TITLE
Fix checkboxes not having unique IDs

### DIFF
--- a/gem/templates/springster/patterns/basics/surveys/surveys-modules/form.html
+++ b/gem/templates/springster/patterns/basics/surveys/surveys-modules/form.html
@@ -18,8 +18,8 @@
       {% if field|fieldtype == 'CheckboxSelectMultiple' %}
           {% for value, text in field.field.choices %}
               <div class="choice-group">
-                  <input name="{{ field.name }}" id="value-{{ field.id_for_label }}-{{ forloop.counter }}" type="checkbox" value="{{ value }}" {% if field.value.0 == value %}checked="checked"{% endif %}/>
-                  <label for="value-{{ field.id_for_label }}-{{ forloop.counter }}">{{ text|capfirst }}</label>
+                  <input name="{{ field.name }}" id="value-{{ field.label|idfromlabel }}-{{ forloop.counter }}" type="checkbox" value="{{ value }}" {% if field.value.0 == value %}checked="checked"{% endif %}/>
+                  <label for="value-{{ field.label|idfromlabel }}-{{ forloop.counter }}">{{ text|capfirst }}</label>
               </div>
           {% endfor %}
       {% elif field|fieldtype == 'RadioSelect' %}

--- a/gem/templatetags/gem_tags.py
+++ b/gem/templatetags/gem_tags.py
@@ -1,3 +1,5 @@
+import re
+
 from django.template import Library
 from django.conf import settings
 
@@ -15,6 +17,15 @@ def get_site_static_prefix():
 @register.filter('fieldtype')
 def fieldtype(field):
     return field.field.widget.__class__.__name__
+
+
+@register.filter(name='idfromlabel')
+def idfromlabel(label):
+    '''
+    return a string that contains only alphanuumeric characters from
+    original string with the prefix 'id_'
+    '''
+    return "id_{}".format(re.sub(r'([^\w]|_)+', '', label.lower()))
 
 
 @register.filter

--- a/gem/tests/templatetags/test_gem_tags.py
+++ b/gem/tests/templatetags/test_gem_tags.py
@@ -2,6 +2,7 @@ from django.test import TestCase
 
 from gem.templatetags.gem_tags import (
     smart_truncate_chars,
+    idfromlabel
 )
 
 
@@ -19,3 +20,12 @@ class TestSmartTruncateChars(TestCase):
         string = 'Thisisateststringwhichislong'
         result = smart_truncate_chars(string, 15)
         self.assertEqual(result, 'Thisisateststr...')
+
+
+class TestIdFromLabelTag(TestCase):
+
+    def test_returns_expected_value(self):
+        self.assertEqual(idfromlabel('I have visited'), 'id_ihavevisited')
+        self.assertEqual(idfromlabel('I have visited . . .'),
+                         'id_ihavevisited')
+        self.assertEqual(idfromlabel('I have visited 1'), 'id_ihavevisited1')


### PR DESCRIPTION
`field.id_for_label` elvaluates to None in the form template. This means that checkboxes ended up with the same id, resulting in incorrect behaviour when checking boxes.

This is a temporary solution and warrants further investigation as to why this particular method fails.

The reason for the custom rendering of the form field, is so that the `<input>` is alongside the `<label>` element, rather than nested inside it, so that it can be styled appropriately.

![kapture 2018-02-19 at 12 07 50](https://user-images.githubusercontent.com/7100966/36374663-c6f4605c-1574-11e8-9982-f9f752c01efb.gif)
