### PR TITLE
Remove unwanted registration fields

### DIFF
--- a/gem/forms.py
+++ b/gem/forms.py
@@ -100,6 +100,15 @@ class GemRegistrationForm(GemAliasMixin, RegistrationForm):
     def clean_alias(self):
         return self._clean_alias()
 
+    def clean_email(self):
+        return None
+
+    def clean_location(self):
+        return None
+
+    def clean_mobile_number(self):
+        return None
+
     def __init__(self, *args, **kwargs):
         super(GemRegistrationForm, self).__init__(*args, **kwargs)
 

--- a/gem/templates/base/profiles/register.html
+++ b/gem/templates/base/profiles/register.html
@@ -45,14 +45,6 @@
           <input id="id_password" maxlength="4" name="password" placeholder="eg. 2086" type="password" required="" pattern="[0-9]*" inputmode="numeric">
         </fieldset>
 
-        {% if settings.profiles.UserProfilesSettings.show_mobile_number_field and settings.profiles.UserProfilesSettings.country_code %}
-          <fieldset>
-            <label>{% trans "Enter your mobile number" %}</label>
-            {{ form.mobile_number }}
-            {{ form.mobile_number.errors }}
-          </fieldset>
-        {% endif %}
-
         {% if settings.profiles.UserProfilesSettings.activate_gender and settings.profiles.UserProfilesSettings.capture_gender_on_reg %}
           <fieldset>
             <label>{% trans "I identify my gender as" %}</label>
@@ -68,24 +60,6 @@
             {{ form.date_of_birth }}
             {{ form.date_of_birth.errors}}
             <p class="helptext">{% trans "Let us know your birthday to get access to exclusive content." %}</p>
-          </fieldset>
-        {% endif %}
-
-        {% if settings.profiles.UserProfilesSettings.show_email_field %}
-          <fieldset>
-            <label for="id_email">{% trans "Enter your email address" %}</label>
-            {{ form.email }}
-            {{ form.email.errors}}
-            <p class="helptext">{% trans "(e.g. example@foo.com)" %}</p>
-          </fieldset>
-        {% endif %}
-
-        {% if settings.profiles.UserProfilesSettings.activate_location and settings.profiles.UserProfilesSettings.capture_location_on_reg %}
-          <fieldset>
-            <label for="location">{% trans "Where do you live?" %}</label>
-            {{ form.location }}
-            {{ form.location.errors}}
-            <p class="helptext">{% trans "Only you will see this." %}</p>
           </fieldset>
         {% endif %}
 

--- a/gem/templates/springster/profiles/register.html
+++ b/gem/templates/springster/profiles/register.html
@@ -72,36 +72,6 @@
             </p>
         </fieldset>
         {% endif %}
-        {% if settings.profiles.UserProfilesSettings.show_mobile_number_field and settings.profiles.UserProfilesSettings.country_code %}
-        <fieldset>
-            <div class="input-group{% if form.mobile_number.errors %} input-error{% endif %}">
-                <label for="id_mobile_number">{% trans "Mobile number" %}</label>
-                {{ form.mobile_number }}
-                {{ from.mobile_number.errors }}
-            </div>
-            <p class="helptext">{% trans "Please add your mobile number e.g. 0719009000" %}</p>
-        </fieldset>
-        {% endif %}
-        {% if settings.profiles.UserProfilesSettings.show_email_field %}
-        <fieldset>
-            <div class="input-group{% if form.email.errors %} input-error{% endif %}">
-                <label for="id_email">{% trans "Enter your email address" %}</label>
-                {{ form.email }}
-                {{ form.email.errors}}
-            </div>
-            <p class="helptext">{% trans "(e.g. example@foo.com)" %}</p>
-        </fieldset>
-        {% endif %}
-        {% if settings.profiles.UserProfilesSettings.activate_location and settings.profiles.UserProfilesSettings.capture_location_on_reg %}
-        <fieldset>
-            <div class="input-group{% if form.location.errors %} input-error{% endif %}">
-                <label for="location">{% trans "Where do you live?" %}</label>
-                {{ form.location }}
-                {{ form.location.errors}}
-            </div>
-            <p class="helptext">{% trans "Only you will see this." %}</p>
-        </fieldset>
-        {% endif %}
         {% if settings.profiles.UserProfilesSettings.activate_education_level and settings.profiles.UserProfilesSettings.capture_education_level_on_reg %}
             <fieldset>
             <div class="input-group{% if form.education_level.errors %} input-error{% endif %}">

--- a/gem/tests/test_forms.py
+++ b/gem/tests/test_forms.py
@@ -8,6 +8,18 @@ class GemRegisterTestCase(TestCase, MoloTestCaseMixin):
     def setUp(self):
         self.mk_main()
 
+    def test_registration_form_removes_unwanted_fields(self):
+        form_data = {
+            'email': 'personal_data@domain.com',
+            'location': '123 Street, City, Country',
+            'mobile_number': '+27710123456',
+        }
+        form = GemRegistrationForm(data=form_data)
+        form.is_valid()
+        self.assertEqual(form.cleaned_data['email'], None)
+        self.assertEqual(form.cleaned_data['location'], None)
+        self.assertEqual(form.cleaned_data['mobile_number'], None)
+
     def test_register_gender_required(self):
         form_data = {
             'username': 'Jeyabal@-1',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-molo.core==6.7.4
+molo.core==6.7.5
 molo.surveys==6.7.1
 molo.commenting==6.2.6
 molo.pwa==6.2.0


### PR DESCRIPTION
Girl Effect never want to collect email addresses, location or mobile numbers during registration, so we should remove them from the form to make it impossible for an accidental misconfiguration to result in them being collected.

https://github.com/praekelt/molo/compare/6.7.4...6.7.5