### PR TITLE
[GEMMOLO-788] Add cache_control decorator to Wagtail views

### DIFF
--- a/gem/tests/test_urls.py
+++ b/gem/tests/test_urls.py
@@ -1,0 +1,22 @@
+from django.test import Client, TestCase
+
+from molo.core.models import SiteLanguageRelation, Main, Languages
+from molo.core.tests.base import MoloTestCaseMixin
+
+
+class TestModels(TestCase, MoloTestCaseMixin):
+    def setUp(self):
+        self.mk_main()
+        main = Main.objects.all().first()
+        language_setting = Languages.objects.create(
+            site_id=main.get_site().pk)
+        SiteLanguageRelation.objects.create(
+            language_setting=language_setting,
+            locale='en',
+            is_active=True)
+
+    def test_cache_control_decorator_for_wagtail_pages(self):
+        client = Client()
+        section = self.mk_section(self.section_index)
+        response = client.get(section.url)
+        self.assertEqual(response['Cache-Control'], 'public, max-age=600')

--- a/gem/tests/test_views.py
+++ b/gem/tests/test_views.py
@@ -310,7 +310,6 @@ class CommentingTestCase(TestCase, MoloTestCaseMixin):
 
     def setUp(self):
         self.mk_main()
-        self.client = ()
         self.main = Main.objects.all().first()
         self.language_setting = Languages.objects.create(
             site_id=self.main.get_site().pk)

--- a/gem/urls.py
+++ b/gem/urls.py
@@ -4,6 +4,7 @@ from django.conf.urls import include, url
 from django.conf.urls.static import static
 from django.conf import settings
 from django.contrib import admin
+from django.views.decorators.cache import cache_control
 from django.views.generic.base import TemplateView
 from django.contrib.auth.decorators import login_required
 from django_cas_ng import views as cas_views
@@ -15,6 +16,7 @@ from wagtail.wagtailcore import urls as wagtail_urls
 from molo.core import views as core_views
 from molo.profiles.views import ForgotPasswordView, ResetPasswordView
 from wagtail.contrib.wagtailsitemaps import views as sitemap_views
+from wagtail.utils.urlpatterns import decorate_urlpatterns
 from gem.views import report_response, GemRegistrationView, \
     GemRssFeed, GemAtomFeed, \
     ReportCommentView, GemEditProfileView, \
@@ -118,9 +120,18 @@ urlpatterns += [
         '(?P<question_id>\d+)/vote/$',
         core_views.ReactionQuestionChoiceView.as_view(),
         name='reaction-vote'),
+]
+
+cacheable_urlpatterns = [
     url(r'', include(wagtail_urls)),
 ]
 
+cacheable_urlpatterns = decorate_urlpatterns(
+    cacheable_urlpatterns,
+    cache_control(public=True, max_age=600),
+)
+
+urlpatterns += cacheable_urlpatterns
 
 if settings.DEBUG:
     from django.contrib.staticfiles.urls import staticfiles_urlpatterns


### PR DESCRIPTION
This pull request will add a `Cache-Control` HTTP header to all the URLs which fall through to be served by Wagtail.

It follows the approach set out by a Wagtail developer: https://github.com/wagtail/wagtail/issues/911#issuecomment-143671219

It means that caching proxies that exist between the end user and our server will cache the HTTP response for 600 seconds (10 minutes). However we already serve a `Vary: Cookie` HTTP header which will instruct the cache to be unique for each cookie. This will ensure it's cached for anonymous users but not for logged-in users.