### PR TITLE
Refactor BBM logic into context processor

### DIFF
--- a/gem/context_processors.py
+++ b/gem/context_processors.py
@@ -1,6 +1,12 @@
 from django.conf import settings
 
 
+def detect_bbm(request):
+    return {
+        'is_via_bbm': 'bbm.' in request.get_host(),
+    }
+
+
 def detect_freebasics(request):
     return {
         'is_via_freebasics':

--- a/gem/settings/base.py
+++ b/gem/settings/base.py
@@ -151,6 +151,7 @@ DEFAULT_TEMPLATE = {
             'django.contrib.messages.context_processors.messages',
             'molo.core.context_processors.locale',
             'wagtail.contrib.settings.context_processors.settings',
+            'gem.context_processors.detect_bbm',
             'gem.context_processors.detect_freebasics',
             'gem.context_processors.compress_settings',
         ],

--- a/gem/templates/springster/base.html
+++ b/gem/templates/springster/base.html
@@ -12,7 +12,7 @@
 <!--<![endif]-->
   <head>
     <meta charset="utf-8"/>
-    <title>{% if 'bbm.' in request.get_host %}GirlTalk{% else %}{% block title %}{% if self.seo_title %}{{ self.seo_title }}{% else %}{{ self.title }}{% endif %}{% endblock %}{% block title_suffix %}{% endblock %}{% endif %}</title>
+    <title>{% if is_via_bbm %}GirlTalk{% else %}{% block title %}{% if self.seo_title %}{{ self.seo_title }}{% else %}{{ self.title }}{% endif %}{% endblock %}{% block title_suffix %}{% endblock %}{% endif %}</title>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="description" content="{% if self.social_media_description %}{{ self.social_media_description }}{% elif self.subtitle %}{{ self.subtitle }}{% elif self.search_description %}{{self.search_description}}{% else %}Springster celebrates the diverse, inspirational and convention‑defying experiences of girls across the world.{% endif %}" />
     <meta name="keywords" content="{% if self.specific.metadata_tags %}{{self.specific.metadata_tags.all|join:','}}{% else %}{{self.seo_title}}{% endif %}" />
@@ -28,7 +28,7 @@
     <meta property="og:image" content="{% if self.social_media_image %}{{ tmp_photo.url }}{% elif article_photo.url %}{{ article_photo.url }}{% else %}{{request.site.root_url}}{% static 'img/springster-fb-share.png' %}{% endif %}"/>
     <meta property="og:image:width" content="450" />
     <meta property="og:image:height" content="200" />
-    <meta name="viewport" content="width=device-width, initial-scale=1{% if 'bbm.' in request.get_host %}, user-scalable=0{% endif %}"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1{% if is_via_bbm %}, user-scalable=0{% endif %}"/>
     <meta name="msapplication-TileColor" content="#ffffff">
     <meta name="msapplication-TileImage" content="{{ STATIC_URL }}img/appicons/springster_icon_144.png">
     <meta name="theme-color" content="#ffffff">
@@ -110,7 +110,7 @@
           {% endblock %}
 
         {% block footer %}
-          {% if 'bbm.' in request.get_host %}
+          {% if is_via_bbm %}
             {% include "patterns/components/footer/sp_variations/footer.html" with type="bbm_home" %}
           {% else %}
             {% include "patterns/components/footer/sp_variations/footer.html" %}
@@ -125,7 +125,7 @@
           {% block facebook_analytics %}
             {% include "core/facebook_analytics.html" %}
           {% endblock %}
-          {% if 'bbm.' in request.get_host %}
+          {% if is_via_bbm %}
             {% include "patterns/components/bbm_partner_ga_code.html" %}
           {% endif %}
         {% endblock %}

--- a/gem/templates/springster/core/section_page.html
+++ b/gem/templates/springster/core/section_page.html
@@ -5,7 +5,7 @@
   {% include "patterns/components/section-page/sp_variations/base-section_teaser-listing.html" %}
 {% endblock %}
 {% block footer %}
-  {% if 'bbm.' in request.get_host %}
+  {% if is_via_bbm %}
     {% include "patterns/components/footer/sp_variations/footer.html" with type="bbm_section" %}
   {% else %}  
     {% include "patterns/components/footer/sp_variations/footer.html" %}

--- a/gem/templates/springster/core/tags/social_media_article.html
+++ b/gem/templates/springster/core/tags/social_media_article.html
@@ -1,4 +1,4 @@
-{% if 'bbm.' in request.get_host %}
+{% if is_via_bbm %}
   {% include "patterns/basics/social-media/social-media_bbm.html" with page=page %}
 {% else%}
   {% include "patterns/basics/social-media/social-media_with-label.html" %}

--- a/gem/templates/springster/patterns/components/article-page/sp_variations/main-article-page.html
+++ b/gem/templates/springster/patterns/components/article-page/sp_variations/main-article-page.html
@@ -2,7 +2,7 @@
 {% get_translation self.get_parent_section as section %}
   {% include "patterns/basics/headings/sp_variations/heading.html" with type="article" htmltag="h1" title=self.title %}
   {% include "patterns/basics/headings/sp_variations/heading.html" with type="subheading" htmltag="h2" title=self.subtitle %}
-  {% if 'bbm.' in request.get_host %}
+  {% if is_via_bbm %}
     {% include "patterns/basics/social-media/social-media_bbm.html" with page=self %}
   {% endif %}
   {% include "patterns/basics/articles/sp_variations/article-comment-counter.html" %}

--- a/gem/tests/test_context_processors.py
+++ b/gem/tests/test_context_processors.py
@@ -1,6 +1,23 @@
 from django.test import RequestFactory, TestCase, override_settings
 
-from gem.context_processors import compress_settings, detect_freebasics
+from gem.context_processors import (
+    compress_settings,
+    detect_bbm,
+    detect_freebasics,
+)
+
+
+class TestDetectBbm(TestCase):
+    def setUp(self):
+        self.request_factory = RequestFactory()
+
+    def test_returns_false_for_requests_without_bbm_host(self):
+        request = self.request_factory.get('/')
+        self.assertEqual(detect_bbm(request), {'is_via_bbm': False})
+
+    def test_returns_true_for_requests_with_bbm_host(self):
+        request = self.request_factory.get('/', HTTP_HOST='bbm.example.com:80')
+        self.assertEqual(detect_bbm(request), {'is_via_bbm': True})
 
 
 class TestDetectFreebasics(TestCase):


### PR DESCRIPTION
Each of these `request.get_host` in the template is a call to the `get_host()` method on a `WSGIRequest`. It's hard to tell because in the template syntax we can call a method without the parentheses.

This probably isn't a massive performance problem but it's unnecessary. It's better to group this logic together so that we only run it once in the context processor. This also means we can test it easily.