### PR TITLE
[GEMMOLO-840] Set ALLOWED_HOSTS correctly

### DIFF
--- a/gem/settings/base.py
+++ b/gem/settings/base.py
@@ -32,18 +32,7 @@ SECRET_KEY = "dqji)!xte^trgai!3c)_4)ftaoevwvbog-i&nl$#ef9xb+y*ab"
 DEBUG = True
 ENV = 'dev'
 
-ALLOWED_HOSTS = [
-    # QA
-    '.molo.unicore.io',
-    '.seed.p16n.org',
-    # Production
-    '.heyspringster.com',
-    'ninyampinga.com',
-    'www.ninyampinga.com',
-    'cewekeren.com',
-    'www.cewekeren.com',
-]
-
+ALLOWED_HOSTS = environ.get('ALLOWED_HOSTS', '').split(",")
 
 # Base URL to use when referring to full URLs within the Wagtail admin
 # backend - e.g. in notification emails. Don't include '/admin' or

--- a/gem/settings/base.py
+++ b/gem/settings/base.py
@@ -32,7 +32,17 @@ SECRET_KEY = "dqji)!xte^trgai!3c)_4)ftaoevwvbog-i&nl$#ef9xb+y*ab"
 DEBUG = True
 ENV = 'dev'
 
-ALLOWED_HOSTS = ['*']
+ALLOWED_HOSTS = [
+    # QA
+    '.molo.unicore.io',
+    '.seed.p16n.org',
+    # Production
+    '.heyspringster.com',
+    'ninyampinga.com',
+    'www.ninyampinga.com',
+    'cewekeren.com',
+    'www.cewekeren.com',
+]
 
 
 # Base URL to use when referring to full URLs within the Wagtail admin

--- a/gem/settings/dev.py
+++ b/gem/settings/dev.py
@@ -1,6 +1,11 @@
 from .base import *  # noqa
 
 
+ALLOWED_HOSTS = [
+    'localhost',
+    '.localhost',
+]
+
 DEBUG = True
 
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'

--- a/gem/tests/test_context_processors.py
+++ b/gem/tests/test_context_processors.py
@@ -16,7 +16,7 @@ class TestDetectBbm(TestCase):
         self.assertEqual(detect_bbm(request), {'is_via_bbm': False})
 
     def test_returns_true_for_requests_with_bbm_host(self):
-        request = self.request_factory.get('/', HTTP_HOST='bbm.example.com:80')
+        request = self.request_factory.get('/', HTTP_HOST='bbm.localhost:80')
         self.assertEqual(detect_bbm(request), {'is_via_bbm': True})
 
 


### PR DESCRIPTION
This is a Django security feature which allows use to protect against HTTP Host header attacks.

https://docs.djangoproject.com/en/1.11/ref/settings/#std:setting-ALLOWED_HOSTS

Instead of setting it to a wildcard we should set it to the hosts we expect to be running this application.

Domains starting with a dot are wildcard subdomains.