### PR TITLE
Add BBM redirect view and use it to detect BBM

### DIFF
--- a/gem/context_processors.py
+++ b/gem/context_processors.py
@@ -2,8 +2,24 @@ from django.conf import settings
 
 
 def detect_bbm(request):
+    '''
+    Detect whether a request has come from BBM. BBM directs users to a /bbm/
+    endpoint which sets a cookie that we can check. Previously we did this
+    using a bbm subdomain, but that is complex to maintain.
+
+    FIXME: Remove hostname check when bbm subdomains for South Africa
+    and Nigeria are no longer used.
+    '''
+    is_via_bbm = False
+
+    if request.COOKIES.get('bbm', 'false') == 'true':
+        is_via_bbm = True
+
+    if 'bbm.' in request.get_host():
+        is_via_bbm = True
+
     return {
-        'is_via_bbm': 'bbm.' in request.get_host(),
+        'is_via_bbm': is_via_bbm,
     }
 
 

--- a/gem/middleware.py
+++ b/gem/middleware.py
@@ -34,11 +34,16 @@ class GemMoloGoogleAnalyticsMiddleware(MoloGoogleAnalyticsMiddleware):
     '''
     def submit_to_local_account(self, request, response, site_settings):
         gem_site_settings = GemSettings.for_site(request.site)
-        subdomain = request.get_host().split(".")[0]
-        if (subdomain == gem_site_settings.bbm_ga_account_subdomain and
-                gem_site_settings.bbm_ga_tracking_code):
-                return self.submit_tracking(
-                    gem_site_settings.bbm_ga_tracking_code, request, response)
+        bbm_ga_code = gem_site_settings.bbm_ga_tracking_code
+        bbm_subdomain = gem_site_settings.bbm_ga_account_subdomain
+        current_subdomain = request.get_host().split(".")[0]
+        should_submit_to_bbm_account = False
+
+        if current_subdomain == bbm_subdomain:
+            should_submit_to_bbm_account = True
+
+        if bbm_ga_code and should_submit_to_bbm_account:
+            return self.submit_tracking(bbm_ga_code, request, response)
         else:
             local_ga_account = site_settings.local_ga_tracking_code or \
                 settings.GOOGLE_ANALYTICS.get('google_analytics_id')

--- a/gem/middleware.py
+++ b/gem/middleware.py
@@ -26,7 +26,7 @@ class ForceDefaultLanguageMiddleware(object):
 class GemMoloGoogleAnalyticsMiddleware(MoloGoogleAnalyticsMiddleware):
     '''
     Submits GA tracking data to a local account or the additional account
-    depending on the subdomain in the request.
+    depending on the subdomain in the request or the bbm cookie.
 
     TODO: Pull the submit_to_local_account and submit_to_global_account
     into the MoloGoogleAnalyticsMiddleware class and override
@@ -40,6 +40,9 @@ class GemMoloGoogleAnalyticsMiddleware(MoloGoogleAnalyticsMiddleware):
         should_submit_to_bbm_account = False
 
         if current_subdomain == bbm_subdomain:
+            should_submit_to_bbm_account = True
+
+        if request.COOKIES.get('bbm', 'false') == 'true':
             should_submit_to_bbm_account = True
 
         if bbm_ga_code and should_submit_to_bbm_account:

--- a/gem/models.py
+++ b/gem/models.py
@@ -147,6 +147,8 @@ class GemSettings(BaseSetting):
         null=True, blank=True,
         help_text='Tracking code for additional Google Analytics account '
                   'to divert traffic that matches a specific subdomain.')
+    # FIXME: Remove bbm_ga_account_subdomain and its uses in middleware once
+    # BBM South Africa and Nigeria are changed to use `/bbm/` cookie endpoint.
     bbm_ga_account_subdomain = models.TextField(
         default='bbm',
         help_text=('Subdomain prefix to seperate traffics data for Google '

--- a/gem/templates/springster/patterns/basics/social-media/social-media_bbm.html
+++ b/gem/templates/springster/patterns/basics/social-media/social-media_bbm.html
@@ -1,9 +1,9 @@
 <ul class="social-media-list">
   <li class="social-media-list__item">
     {% if type == "footer" %}
-      <a href="bbmi:///api/share?message=http{% if request.is_secure %}s{%endif %}://{{ request.get_host }}{{ request.path }}" class="call-to-action__item-share call-to-action__nav-item-share--bbm"></a>
+      <a href="bbmi:///api/share?message={{ request.build_absolute_uri }}" class="call-to-action__item-share call-to-action__nav-item-share--bbm"></a>
     {% else %}
-      <a href="bbmi:///api/share?message=http{% if request.is_secure %}s{%endif %}://{{ request.get_host }}{{ request.path }}&userCustomMessage={{ page.title | upper }} | {{page.subtitle}}" class="call-to-action__item-share call-to-action__nav-item-share--bbm"></a>
+      <a href="bbmi:///api/share?message={{ request.build_absolute_uri }}&userCustomMessage={{ page.title | upper }} | {{page.subtitle}}" class="call-to-action__item-share call-to-action__nav-item-share--bbm"></a>
     {% endif %}
     </li>
 </ul>

--- a/gem/templates/springster/patterns/basics/social-media/social-media_bbm.html
+++ b/gem/templates/springster/patterns/basics/social-media/social-media_bbm.html
@@ -1,9 +1,10 @@
+{% load gem_tags %}
 <ul class="social-media-list">
   <li class="social-media-list__item">
     {% if type == "footer" %}
-      <a href="bbmi:///api/share?message={{ request.build_absolute_uri }}" class="call-to-action__item-share call-to-action__nav-item-share--bbm"></a>
+      <a href="bbmi:///api/share?message={% bbm_share_url %}" class="call-to-action__item-share call-to-action__nav-item-share--bbm"></a>
     {% else %}
-      <a href="bbmi:///api/share?message={{ request.build_absolute_uri }}&userCustomMessage={{ page.title | upper }} | {{page.subtitle}}" class="call-to-action__item-share call-to-action__nav-item-share--bbm"></a>
+      <a href="bbmi:///api/share?message={% bbm_share_url %}&userCustomMessage={{ page.title | upper }} | {{page.subtitle}}" class="call-to-action__item-share call-to-action__nav-item-share--bbm"></a>
     {% endif %}
     </li>
 </ul>

--- a/gem/templatetags/gem_tags.py
+++ b/gem/templatetags/gem_tags.py
@@ -1,5 +1,6 @@
 import re
 
+from django.core.urlresolvers import reverse
 from django.template import Library
 from django.conf import settings
 
@@ -7,6 +8,16 @@ from gem.constants import GENDER
 from gem.models import GemTextBanner
 from molo.core.templatetags.core_tags import get_pages
 register = Library()
+
+
+@register.simple_tag(takes_context=True)
+def bbm_share_url(context):
+    req = context['request']
+    uri = reverse(
+        'bbm_redirect',
+        kwargs={'redirect_path': req.get_full_path().lstrip('/')},
+    )
+    return req.build_absolute_uri(uri)
 
 
 @register.simple_tag()

--- a/gem/tests/templatetags/test_gem_tags.py
+++ b/gem/tests/templatetags/test_gem_tags.py
@@ -1,9 +1,19 @@
-from django.test import TestCase
+from django.template import Context
+from django.test import RequestFactory, TestCase
 
 from gem.templatetags.gem_tags import (
+    bbm_share_url,
     smart_truncate_chars,
     idfromlabel
 )
+
+
+class TestBbmShareUrl(TestCase):
+    def test_returns_url_prefixed_with_bbm(self):
+        request = RequestFactory().get('/section/one/')
+        context = Context({'request': request})
+        result = bbm_share_url(context)
+        self.assertEqual(result, 'http://testserver/bbm/section/one/')
 
 
 class TestSmartTruncateChars(TestCase):

--- a/gem/tests/test_context_processors.py
+++ b/gem/tests/test_context_processors.py
@@ -11,12 +11,17 @@ class TestDetectBbm(TestCase):
     def setUp(self):
         self.request_factory = RequestFactory()
 
-    def test_returns_false_for_requests_without_bbm_host(self):
+    def test_returns_false_for_requests_without_bbm_cookie(self):
         request = self.request_factory.get('/')
         self.assertEqual(detect_bbm(request), {'is_via_bbm': False})
 
     def test_returns_true_for_requests_with_bbm_host(self):
         request = self.request_factory.get('/', HTTP_HOST='bbm.example.com:80')
+        self.assertEqual(detect_bbm(request), {'is_via_bbm': True})
+
+    def test_returns_true_for_requests_with_bbm_cookie(self):
+        request = self.request_factory.get('/')
+        request.COOKIES['bbm'] = 'true'
         self.assertEqual(detect_bbm(request), {'is_via_bbm': True})
 
 

--- a/gem/tests/test_middleware.py
+++ b/gem/tests/test_middleware.py
@@ -52,6 +52,25 @@ class TestCustomGemMiddleware(TestCase, MoloTestCaseMixin):
             'bbm_tracking_code', request, self.response)
 
     @patch(submit_tracking_method)
+    def test_submit_to_bbm_analytics_if_cookie_set(self, mock_submit_tracking):
+        '''
+        Given that bbm_ga_account_subdomain and bbm_ga_tracking_code
+        are set in Gem Settings, and the BBM cookie is set, info
+        should be sent to the additional GA account.
+        '''
+
+        request = RequestFactory().get('/', HTTP_HOST='example.com')
+        request.COOKIES['bbm'] = 'true'
+        request.site = self.site
+
+        middleware = GemMoloGoogleAnalyticsMiddleware()
+        middleware.submit_to_local_account(
+            request, self.response, self.site_settings)
+
+        mock_submit_tracking.assert_called_once_with(
+            'bbm_tracking_code', request, self.response)
+
+    @patch(submit_tracking_method)
     def test_submit_to_local_ga_account(self, mock_submit_tracking):
         '''
         Given that bbm_ga_account_subdomain and bbm_ga_tracking_code

--- a/gem/tests/test_middleware.py
+++ b/gem/tests/test_middleware.py
@@ -1,92 +1,71 @@
-import mock
-from django.test import TestCase
+from django.test import RequestFactory, TestCase
 from django.test.client import Client
 
 from gem.middleware import GemMoloGoogleAnalyticsMiddleware
-from molo.core.models import (
-    Main,
-    Languages,
-    SiteLanguageRelation,
-)
+from gem.models import GemSettings
+
+from mock import patch
+
+from molo.core.models import SiteSettings
 from molo.core.tests.base import MoloTestCaseMixin
 
 
 class TestCustomGemMiddleware(TestCase, MoloTestCaseMixin):
 
+    submit_tracking_method = (
+        "gem.middleware.GemMoloGoogleAnalyticsMiddleware.submit_tracking"
+    )
+
     def setUp(self):
         self.client = Client()
-        # Creates Main language
         self.mk_main()
-        main = Main.objects.all().first()
-        self.english = SiteLanguageRelation.objects.create(
-            language_setting=Languages.for_site(main.get_site()),
-            locale='en',
-            is_active=True)
-        # Creates a section under the index page
-        self.english_section = self.mk_section(
-            self.section_index, title='English section')
 
-        # fake the site settings
-        self.site_settings = mock.Mock()
+        self.site_settings = SiteSettings.for_site(self.site)
         self.site_settings.local_ga_tracking_code = 'local_ga_tracking_code'
+        self.site_settings.save()
 
-        # fake the gem settings
-        self.gem_settings = mock.Mock()
-        self.gem_settings.bbm_ga_account_subdomain = 'bbm'
-        self.gem_settings.bbm_ga_tracking_code = "bbm_tracking_code"
+        GemSettings.objects.create(
+            site_id=self.site.id,
+            bbm_ga_account_subdomain='bbm',
+            bbm_ga_tracking_code='bbm_tracking_code',
+        )
 
-        self.request = mock.Mock()
-        self.request.site = self.site
+        self.response = self.client.get('/')
 
-    @mock.patch("gem.middleware.GemMoloGoogleAnalyticsMiddleware.submit_tracking")  # noqa
-    @mock.patch("gem.models.GemSettings.for_site")
-    def test_submit_to_additional_ga_account(self, mock_get_gem_settings,
-                                             mock_submit_tracking):
+    @patch(submit_tracking_method)
+    def test_submit_to_additional_ga_account(self, mock_submit_tracking):
         '''
         Given that bbm_ga_account_subdomain and bbm_ga_tracking_code
         are set in Gem Settings, and the URL contains the
         bbm_ga_account_subdomain, info should be sent to
         the additional GA account.
         '''
-        mock_get_gem_settings.return_value = self.gem_settings
 
-        self.request.get_host.return_value = (
-            '{}.za.heyspringster.com'.format(
-                self.gem_settings.bbm_ga_account_subdomain)
-        )
-
-        request = self.request
-        response = self.client.get('/')
+        request = RequestFactory().get('/', HTTP_HOST='bbm.example.com')
+        request.site = self.site
 
         middleware = GemMoloGoogleAnalyticsMiddleware()
         middleware.submit_to_local_account(
-            request, response, self.site_settings)
+            request, self.response, self.site_settings)
 
         mock_submit_tracking.assert_called_once_with(
-            self.gem_settings.bbm_ga_tracking_code,
-            request, response)
+            'bbm_tracking_code', request, self.response)
 
-    @mock.patch("gem.middleware.GemMoloGoogleAnalyticsMiddleware.submit_tracking")  # noqa
-    @mock.patch("gem.models.GemSettings.for_site")
-    def test_submit_to_local_ga_account(self, mock_get_gem_settings,
-                                        mock_submit_tracking):
+    @patch(submit_tracking_method)
+    def test_submit_to_local_ga_account(self, mock_submit_tracking):
         '''
         Given that bbm_ga_account_subdomain and bbm_ga_tracking_code
         are set in Gem Settings, and the URL does not contain the
         bbm_ga_account_subdomain, info should be sent to
         the local GA account, not the additional GA account.
         '''
-        mock_get_gem_settings.return_value = self.gem_settings
 
-        self.request.get_host.return_value = 'za.heyspringster.com'
-
-        request = self.request
-        response = self.client.get('/')
+        request = RequestFactory().get('/', HTTP_HOST='example.com')
+        request.site = self.site
 
         middleware = GemMoloGoogleAnalyticsMiddleware()
         middleware.submit_to_local_account(
-            request, response, self.site_settings)
+            request, self.response, self.site_settings)
 
         mock_submit_tracking.assert_called_once_with(
-            self.site_settings.local_ga_tracking_code,
-            request, response)
+            'local_ga_tracking_code', request, self.response)

--- a/gem/tests/test_views.py
+++ b/gem/tests/test_views.py
@@ -528,9 +528,22 @@ class TestBbmRedirectView(TestCase, MoloTestCaseMixin):
         self.client = Client()
 
     def test_it_sets_cookie_for_bbm(self):
-        response = self.client.get(reverse('bbm_redirect'))
+        response = self.client.get('/bbm/')
         self.assertEqual(response.cookies['bbm'].value, 'true')
 
     def test_it_redirects_to_homepage(self):
-        response = self.client.get(reverse('bbm_redirect'))
-        self.assertEqual(response['Location'], '/')
+        response = self.client.get('/bbm/')
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response['Location'], 'http://testserver/')
+
+    def test_it_redirects_to_specified_location(self):
+        response = self.client.get('/bbm/section/one/')
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response['Location'],
+            'http://testserver/section/one/',
+        )
+
+    def test_it_returns_bad_request_if_url_unsafe(self):
+        response = self.client.get('/bbm//http://evil.com/')
+        self.assertEqual(response.status_code, 400)

--- a/gem/tests/test_views.py
+++ b/gem/tests/test_views.py
@@ -520,3 +520,17 @@ class GemReportCommentViewTest(TestCase, MoloTestCaseMixin):
         response = self.client.get(
             reverse('report_response', args=(comment.pk,)))
         self.assertContains(response, 'This comment has been reported.')
+
+
+class TestBbmRedirectView(TestCase, MoloTestCaseMixin):
+    def setUp(self):
+        self.mk_main()
+        self.client = Client()
+
+    def test_it_sets_cookie_for_bbm(self):
+        response = self.client.get(reverse('bbm_redirect'))
+        self.assertEqual(response.cookies['bbm'].value, 'true')
+
+    def test_it_redirects_to_homepage(self):
+        response = self.client.get(reverse('bbm_redirect'))
+        self.assertEqual(response['Location'], '/')

--- a/gem/urls.py
+++ b/gem/urls.py
@@ -15,10 +15,13 @@ from wagtail.wagtailcore import urls as wagtail_urls
 from molo.core import views as core_views
 from molo.profiles.views import ForgotPasswordView, ResetPasswordView
 from wagtail.contrib.wagtailsitemaps import views as sitemap_views
-from gem.views import report_response, GemRegistrationView, \
-    GemRssFeed, GemAtomFeed, \
-    ReportCommentView, GemEditProfileView, \
-    AlreadyReportedCommentView, GemRegistrationDoneView
+from gem.views import (
+    report_response, GemRegistrationView,
+    GemRssFeed, GemAtomFeed,
+    ReportCommentView, GemEditProfileView,
+    AlreadyReportedCommentView, GemRegistrationDoneView,
+    BbmRedirect,
+)
 
 urlpatterns = []
 
@@ -38,6 +41,8 @@ urlpatterns += [
         template_name='robots.txt', content_type='text/plain')),
     url(r'^sitemap\.xml$', sitemap_views.sitemap),
     url(r'^documents/', include(wagtaildocs_urls)),
+
+    url(r'^bbm/$', BbmRedirect.as_view(), name='bbm_redirect'),
 
     url(r'', include('molo.pwa.urls')),
     url(r'^profiles/register/$',

--- a/gem/urls.py
+++ b/gem/urls.py
@@ -42,7 +42,8 @@ urlpatterns += [
     url(r'^sitemap\.xml$', sitemap_views.sitemap),
     url(r'^documents/', include(wagtaildocs_urls)),
 
-    url(r'^bbm/$', BbmRedirect.as_view(), name='bbm_redirect'),
+    url(r'^bbm/(?P<redirect_path>.*)$',
+        BbmRedirect.as_view(), name='bbm_redirect'),
 
     url(r'', include('molo.pwa.urls')),
     url(r'^profiles/register/$',

--- a/gem/views.py
+++ b/gem/views.py
@@ -8,6 +8,7 @@ from django.http.response import HttpResponseForbidden
 from django.shortcuts import render
 from django.utils.feedgenerator import Atom1Feed
 from django.utils.translation import ugettext_lazy as _
+from django.views import View
 from django.views.generic import TemplateView
 from django.views.generic.edit import FormView
 
@@ -201,3 +202,10 @@ class AlreadyReportedCommentView(TemplateView):
         return self.render_to_response({
             'article': comment.content_object
         })
+
+
+class BbmRedirect(View):
+    def get(self, request):
+        response = HttpResponseRedirect('/')
+        response.set_cookie('bbm', 'true')
+        return response

--- a/gem/views.py
+++ b/gem/views.py
@@ -3,10 +3,11 @@ import re
 from django import forms
 from django.contrib.syndication.views import Feed
 from django.core.urlresolvers import reverse
-from django.http import HttpResponseRedirect
+from django.http import HttpResponseBadRequest, HttpResponseRedirect
 from django.http.response import HttpResponseForbidden
 from django.shortcuts import render
 from django.utils.feedgenerator import Atom1Feed
+from django.utils.http import is_safe_url
 from django.utils.translation import ugettext_lazy as _
 from django.views import View
 from django.views.generic import TemplateView
@@ -205,7 +206,14 @@ class AlreadyReportedCommentView(TemplateView):
 
 
 class BbmRedirect(View):
-    def get(self, request):
-        response = HttpResponseRedirect('/')
-        response.set_cookie('bbm', 'true')
+    def get(self, request, redirect_path):
+        destination = request.build_absolute_uri('/{0}'.format(redirect_path))
+        allowed_hosts = [request.get_host()]
+
+        if is_safe_url(destination, allowed_hosts=allowed_hosts):
+            response = HttpResponseRedirect(destination)
+            response.set_cookie('bbm', 'true')
+        else:
+            response = HttpResponseBadRequest('Redirect URL is unsafe')
+
         return response


### PR DESCRIPTION
This is easier to maintain than separate domain names for BBM. My hope is that we can direct users to the `/bbm/` endpoint which will redirect them to the homepage but mark them as BBM users.