### PR TITLE
allowing translations for anonymous commenting

### DIFF
--- a/gem/templates/base/comments/comment.html
+++ b/gem/templates/base/comments/comment.html
@@ -14,7 +14,7 @@
           {% trans "Big Sister" %}
         {% endif %}
     {% elif node.user_name.lower == 'anonymous' %}
-      {{node.user_name}}
+      {% trans "Anonymous" %}
     {% else %}
       {% if not node.user.profile.alias %}
         {% trans "Anonymous" %}


### PR DESCRIPTION
Anonymous commenting was not being translated because we were passing a variable name and not text we can actually translate. 