### PR TITLE
Add health URL when in maintenance mode

### DIFF
--- a/gem/urls.py
+++ b/gem/urls.py
@@ -141,5 +141,9 @@ if settings.DEBUG:
 
 if settings.MAINTENANCE_MODE:
     urlpatterns = [
+        url(
+            r'^health/$',
+            core_views.health,
+        ),
         url(r'', MaintenanceView.as_view()),
     ]


### PR DESCRIPTION
Mesos/Marathon still needs to be able to check the health of the app.