### PR TITLE
Fix silent template exceptions

### DIFF
--- a/gem/templates/springster/base.html
+++ b/gem/templates/springster/base.html
@@ -14,24 +14,32 @@
     <meta charset="utf-8"/>
     <title>{% if is_via_bbm %}GirlTalk{% else %}{% block title %}{% if self.seo_title %}{{ self.seo_title }}{% else %}{{ self.title }}{% endif %}{% endblock %}{% block title_suffix %}{% endblock %}{% endif %}</title>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="description" content="{% if self.social_media_description %}{{ self.social_media_description }}{% elif self.subtitle %}{{ self.subtitle }}{% elif self.search_description %}{{self.search_description}}{% else %}Springster celebrates the diverse, inspirational and convention‑defying experiences of girls across the world.{% endif %}" />
-    <meta name="keywords" content="{% if self.specific.metadata_tags %}{{self.specific.metadata_tags.all|join:','}}{% else %}{{self.seo_title}}{% endif %}" />
     <meta name="twitter:card" content="summary_large_image"/>
-    {% image self.social_media_image fill-450x200 as tmp_photo %}
-    {% if self.get_effective_image %}
-      {% image self.get_effective_image fill-450x200 as article_photo %}
-    {% endif %}
     <meta name="google-site-verification" content="1pHfu6F9poexdHOYO-8YohY4exchMmVOaNmiCLhoT9Q" />
-    <meta property="og:title" content= "{% if self.social_media_title %}{{ self.social_media_title }}{% elif self.seo_title %}{{ self.seo_title }}{% else %}{{ self.title }}{% endif %}" />
-    <meta property="og:description" content="{% if self.search_description %}{{ self.search_description }}{% elif self.social_media_description %}{{ self.social_media_description }}{% else %}{{ self.subtitle }}{% endif %}"/>
     <meta property="og:url" content="{{ request.build_absolute_uri }}" />
-    <meta property="og:image" content="{% if self.social_media_image %}{{ tmp_photo.url }}{% elif article_photo.url %}{{ article_photo.url }}{% else %}{{request.site.root_url}}{% static 'img/springster-fb-share.png' %}{% endif %}"/>
     <meta property="og:image:width" content="450" />
     <meta property="og:image:height" content="200" />
     <meta name="viewport" content="width=device-width, initial-scale=1{% if is_via_bbm %}, user-scalable=0{% endif %}"/>
     <meta name="msapplication-TileColor" content="#ffffff">
     <meta name="msapplication-TileImage" content="{{ STATIC_URL }}img/appicons/springster_icon_144.png">
     <meta name="theme-color" content="#ffffff">
+
+    {% comment %}
+    This meta block is overriden in some child templates because not all of the properties
+    used here are available on every model.
+    {% endcomment %}
+    {% block meta %}
+    {% image self.social_media_image fill-450x200 as tmp_photo %}
+    {% if self.get_effective_image %}
+      {% image self.get_effective_image fill-450x200 as article_photo %}
+    {% endif %}
+    <meta name="description" content="{% if self.social_media_description %}{{ self.social_media_description }}{% elif self.subtitle %}{{ self.subtitle }}{% elif self.search_description %}{{self.search_description}}{% else %}Springster celebrates the diverse, inspirational and convention‑defying experiences of girls across the world.{% endif %}" />
+    <meta name="keywords" content="{% if self.specific.metadata_tags %}{{self.specific.metadata_tags.all|join:','}}{% else %}{{self.seo_title}}{% endif %}" />
+    <meta property="og:title" content="{% if self.social_media_title %}{{ self.social_media_title }}{% elif self.seo_title %}{{ self.seo_title }}{% else %}{{ self.title }}{% endif %}" />
+    <meta property="og:description" content="{% if self.search_description %}{{ self.search_description }}{% elif self.social_media_description %}{{ self.social_media_description }}{% else %}{{ self.subtitle }}{% endif %}"/>
+    <meta property="og:image" content="{% if self.social_media_image %}{{ tmp_photo.url }}{% elif article_photo.url %}{{ article_photo.url }}{% else %}{{request.site.root_url}}{% static 'img/springster-fb-share.png' %}{% endif %}"/>
+    {% endblock %}
+
     <link rel="apple-touch-icon" sizes="144x144" href="{{ STATIC_URL }}img/appicons/springster_icon_144.png">
     <link rel="apple-touch-icon" sizes="180x180" href="{{ STATIC_URL }}img/appicons/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="192x192"  href="{{ STATIC_URL }}img/appicons/springster_icon_192.png">

--- a/gem/templates/springster/base.html
+++ b/gem/templates/springster/base.html
@@ -136,7 +136,9 @@
           <div class="header__search-bar">
             <div class="search-bar">
               <form action="{% url 'search' %}" novalidate>
-                <input placeholder="{% trans "Search" %}" name="q" type="text" value="{{search_query}}" id="input__none">
+                {% block search_input_header %}
+                <input placeholder="{% trans "Search" %}" name="q" type="text" id="input__none">
+                {% endblock search_input_header %}
                 <input type="submit" value="{% trans "Search" %}" class="call-to-action__item call-to-action__item--with-icon call-to-action__item--search-icon">
               </form>
             </div>
@@ -182,7 +184,9 @@
           <div id="gem-footer">
             <div class="search-bar">
               <form action="{% url 'search' %}" novalidate>
-                <input placeholder="{% trans "Search" %}" name="q" type="text" value="{{search_query}}" id="input__none">
+                {% block search_input_footer %}
+                <input placeholder="{% trans "Search" %}" name="q" type="text" id="input__none">
+                {% endblock search_input_footer %}
                 <input type="submit" value="{% trans "Search" %}" class="call-to-action__item call-to-action__item--with-icon call-to-action__item--search-icon">
               </form>
             </div>

--- a/gem/templates/springster/core/main.html
+++ b/gem/templates/springster/core/main.html
@@ -1,6 +1,14 @@
 {% extends "base.html" %}
 {% load cache wagtailcore_tags core_tags wagtailimages_tags staticfiles comments molo_survey_tags poll_votings competition_tag el_pagination_tags gem_media_tags gem_tags %}
 
+{% block meta %}
+    <meta name="description" content="{% if self.search_description %}{{self.search_description}}{% else %}Springster celebrates the diverse, inspirational and convention‑defying experiences of girls across the world.{% endif %}" />
+    <meta name="keywords" content="{{ self.seo_title }}" />
+    <meta property="og:title" content="{% if self.seo_title %}{{ self.seo_title }}{% else %}{{ self.title }}{% endif %}" />
+    <meta property="og:description" content="{{ self.search_description }}"/>
+    <meta property="og:image" content="{{request.site.root_url}}{% static 'img/springster-fb-share.png' %}"/>
+{% endblock %}
+
 {% block content %}
   {% cache 900 main_banners_top request.site locale_code %}
     {% bannerpages position=0 %}

--- a/gem/templates/springster/search/search_results.html
+++ b/gem/templates/springster/search/search_results.html
@@ -2,6 +2,15 @@
 {% load el_pagination_tags wagtailcore_tags core_tags wagtailimages_tags staticfiles gem_tags comments %}
 
 {% block body_class %}default-container{% endblock %}
+
+{% block search_input_header %}
+  <input placeholder="{% trans "Search" %}" name="q" type="text" value="{{search_query}}" id="input__none">
+{% endblock %}
+
+{% block search_input_footer %}
+  <input placeholder="{% trans "Search" %}" name="q" type="text" value="{{search_query}}" id="input__none">
+{% endblock %}
+
 {% block content %}
 <div class="search search-results">
   <div class="heading heading__component">


### PR DESCRIPTION
##  Override main page meta tags to remove silent exceptions

When I load the homepage in development I get thousands of log lines of exceptions and 264 instances of the word "Traceback".

This is because we're accessing lots of properties in the meta tags which the Main model doesn't have.

To fix it I've overriden the meta tags on the main page so that we don't try and access those properties, which gets rid of the exceptions. Locally it takes the number of tracebacks from 264 to 132.

##  Override search input on search results page

Currently we're trying to access `search_query` in the base template which causes a silent exception on every page except the search results page.

Instead we should override that bit of the template on the search results page to maintain the behaviour and prevent the exceptions.