### PR TITLE
Add django-allow-cidr

### DIFF
--- a/gem/settings/base.py
+++ b/gem/settings/base.py
@@ -43,6 +43,8 @@ ENV = 'dev'
 MAINTENANCE_MODE = environ.get('MAINTENANCE_MODE', '') == 'true'
 
 ALLOWED_HOSTS = environ.get('ALLOWED_HOSTS', '').split(",")
+ALLOWED_CIDR_NETS = [
+    net for net in environ.get('ALLOWED_CIDR_NETS', '').split(",") if net]
 
 # Base URL to use when referring to full URLs within the Wagtail admin
 # backend - e.g. in notification emails. Don't include '/admin' or
@@ -116,6 +118,7 @@ COMMENTS_HIDE_REMOVED = False
 SITE_ID = 1
 
 MIDDLEWARE_CLASSES = [
+    'allow_cidr.middleware.AllowCIDRMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'molo.core.middleware.ForceDefaultLanguageMiddleware',
     'django.middleware.locale.LocaleMiddleware',

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ Unidecode==0.04.16
 gunicorn
 psycopg2
 django_compressor==2.2
+django-allow-cidr==0.3.0
 django-mptt==0.8.7
 django-google-analytics-app==4.2.0
 django-storages


### PR DESCRIPTION
This will allow us to set ALLOWED_HOSTS to include IP address ranges which is necessary in the new core infrastructure.