### PR TITLE
Remove is_via_bbm from molo.core template tag

### DIFF
--- a/gem/templates/springster/core/article_page.html
+++ b/gem/templates/springster/core/article_page.html
@@ -63,7 +63,15 @@
       {% endif %}
     {% endfor %}
   </article>
-  {% social_media_article page=self %}
+  {% if is_via_bbm %}
+    <ul class="social-media-list">
+      <li class="social-media-list__item">
+        <a href="bbmi:///api/share?message={% bbm_share_url %}&userCustomMessage={{ page.title | upper }} | {{page.subtitle}}" class="call-to-action__item-share call-to-action__nav-item-share--bbm"></a>
+      </li>
+    </ul>
+  {% else %}
+    {% social_media_article page=self %}
+  {% endif %}
   {% load_reaction_question article as question %}
   {% if question %}
   <div class="reaction-questions__block">

--- a/gem/templates/springster/core/tags/social_media_article.html
+++ b/gem/templates/springster/core/tags/social_media_article.html
@@ -1,12 +1,7 @@
-{% load wagtailsettings_tags gem_tags %}
+{% load wagtailsettings_tags %}
 {% get_settings %}
 
   <ul class="social-media-list">
-  {% if is_via_bbm %}
-    <li class="social-media-list__item">
-      <a href="bbmi:///api/share?message={% bbm_share_url %}&userCustomMessage={{ page.title | upper }} | {{page.subtitle}}" class="call-to-action__item-share call-to-action__nav-item-share--bbm"></a>
-    </li>
-  {% else %}
       <li class="social-media-list__item">
         <label class="social-media__label">{% trans "Share" %}</label>
       </li>
@@ -22,5 +17,4 @@
           </a>
         {% endif %}
       </li>
-  {% endif %}
   </ul>

--- a/gem/templates/springster/patterns/components/article-page/sp_variations/main-article-page.html
+++ b/gem/templates/springster/patterns/components/article-page/sp_variations/main-article-page.html
@@ -73,7 +73,15 @@
       {% endif %}
     {% endfor %}
   </article>
-  {% social_media_article page=self %}
+  {% if is_via_bbm %}
+    <ul class="social-media-list">
+      <li class="social-media-list__item">
+        <a href="bbmi:///api/share?message={% bbm_share_url %}&userCustomMessage={{ page.title | upper }} | {{page.subtitle}}" class="call-to-action__item-share call-to-action__nav-item-share--bbm"></a>
+      </li>
+    </ul>
+  {% else %}
+    {% social_media_article page=self %}
+  {% endif %}
   {% load_reaction_question article as question %}
   {% if question %}
   <div class="reaction-questions__block">


### PR DESCRIPTION
is_via_bbm is only available in the context in the molo-gem repository, which means we can't use it inside a molo.core template tag like social_media_article.

This commit puts the conditional in a template which is rendered by molo-gem so the context variable is available.