### PR TITLE
Update auth links with correct settings for multisite

### DIFF
--- a/gem/context_processors.py
+++ b/gem/context_processors.py
@@ -33,12 +33,39 @@ def detect_freebasics(request):
 
 
 def compress_settings(request):
+    REGISTRATION_URL = settings.REGISTRATION_URL
+    EDIT_PROFILE_URL = settings.EDIT_PROFILE_URL
+    VIEW_PROFILE_URL = settings.VIEW_PROFILE_URL
+
+    if settings.USE_OIDC_AUTHENTICATION:
+        site = request.site
+        if not hasattr(site, "oidcsettings"):
+            raise RuntimeError(
+                "Site {} has no settings configured.".format(site))
+
+        oidc_settings = site.oidcsettings
+        if oidc_settings:
+            REGISTRATION_URL = (
+                "%s/registration/?theme=%s&hide=end-user&redirect_uri=%s" % (
+                    settings.OIDC_OP, settings.THEME,
+                    oidc_settings.wagtail_redirect_url))
+            VIEW_PROFILE_URL = (
+                "%s/profile/edit/?theme=%s&redirect_uri=%s&client_id=%s" % (
+                    settings.OIDC_OP, settings.THEME,
+                    oidc_settings.wagtail_redirect_url,
+                    oidc_settings.oidc_rp_client_id))
+            EDIT_PROFILE_URL = (
+                "%s/profile/edit/?theme=%s&redirect_uri=%s&client_id=%s" % (
+                    settings.OIDC_OP, settings.THEME,
+                    oidc_settings.wagtail_redirect_url,
+                    oidc_settings.oidc_rp_client_id))
+
     return {
         'STATIC_URL': settings.STATIC_URL,
         'ENV': settings.ENV,
-        'REGISTRATION_URL': settings.REGISTRATION_URL,
-        'EDIT_PROFILE_URL': settings.EDIT_PROFILE_URL,
-        'VIEW_PROFILE_URL': settings.VIEW_PROFILE_URL,
+        'REGISTRATION_URL': REGISTRATION_URL,
+        'EDIT_PROFILE_URL': EDIT_PROFILE_URL,
+        'VIEW_PROFILE_URL': VIEW_PROFILE_URL,
         'LOGIN_URL': settings.LOGIN_URL,
         'LOGOUT_URL': settings.LOGOUT_URL,
     }

--- a/gem/settings/base.py
+++ b/gem/settings/base.py
@@ -61,17 +61,20 @@ OIDC_CALLBACK_CLASS = "gem.views.CustomAuthenticationCallbackView"
 OIDC_OP_LOGOUT_URL = environ.get("OIDC_OP_LOGOUT_URL", "")
 
 if USE_OIDC_AUTHENTICATION:
+    oidc_settings = "gem.utils.get_oidc_settings"
     LOGIN_URL = 'oidc_authentication_init'
     LOGOUT_URL = 'oidc_logout'
     REGISTRATION_URL = (
         "%s/registration/?theme=%s&hide=end-user&redirect_url=%s" % (
-            OIDC_OP, THEME, WAGTAIL_REDIRECT_URL))
+            OIDC_OP, THEME, oidc_settings.WAGTAIL_REDIRECT_URL))
     VIEW_PROFILE_URL = (
         "%s/profile/edit/?theme=%s&redirect_uri=%s&client_id=%s" % (
-            OIDC_OP, THEME, WAGTAIL_REDIRECT_URL, OIDC_RP_CLIENT_ID))
+            OIDC_OP, THEME, oidc_settings.WAGTAIL_REDIRECT_URL,
+            oidc_settings.OIDC_RP_CLIENT_ID))
     EDIT_PROFILE_URL = (
         "%s/profile/edit/?theme=%s&redirect_uri=%s&client_id=%s" % (
-            OIDC_OP, THEME, WAGTAIL_REDIRECT_URL, OIDC_RP_CLIENT_ID))
+            OIDC_OP, THEME, oidc_settings.WAGTAIL_REDIRECT_URL,
+            oidc_settings.OIDC_RP_CLIENT_ID))
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True

--- a/gem/settings/base.py
+++ b/gem/settings/base.py
@@ -61,20 +61,8 @@ OIDC_CALLBACK_CLASS = "gem.views.CustomAuthenticationCallbackView"
 OIDC_OP_LOGOUT_URL = environ.get("OIDC_OP_LOGOUT_URL", "")
 
 if USE_OIDC_AUTHENTICATION:
-    oidc_settings = "gem.utils.get_oidc_settings"
     LOGIN_URL = 'oidc_authentication_init'
     LOGOUT_URL = 'oidc_logout'
-    REGISTRATION_URL = (
-        "%s/registration/?theme=%s&hide=end-user&redirect_url=%s" % (
-            OIDC_OP, THEME, oidc_settings.WAGTAIL_REDIRECT_URL))
-    VIEW_PROFILE_URL = (
-        "%s/profile/edit/?theme=%s&redirect_uri=%s&client_id=%s" % (
-            OIDC_OP, THEME, oidc_settings.WAGTAIL_REDIRECT_URL,
-            oidc_settings.OIDC_RP_CLIENT_ID))
-    EDIT_PROFILE_URL = (
-        "%s/profile/edit/?theme=%s&redirect_uri=%s&client_id=%s" % (
-            OIDC_OP, THEME, oidc_settings.WAGTAIL_REDIRECT_URL,
-            oidc_settings.OIDC_RP_CLIENT_ID))
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True

--- a/gem/tests/test_auth.py
+++ b/gem/tests/test_auth.py
@@ -248,6 +248,10 @@ class TestOIDCAuthIntegration(TestCase, GemTestCaseMixin):
 
     @override_settings(LOGOUT_URL='oidc_logout')
     def test_admin_logout_button_when_oidc_is_true(self):
+        OIDCSettings.objects.create(
+            site=self.main.get_site(), oidc_rp_client_secret='secret',
+            oidc_rp_client_id='id',
+            wagtail_redirect_url='http://main1.localhost:8000')
         # check that users need to login
         response = self.client.get('/admin/')
         self.assertEquals(response['location'], "/admin/login/?next=/admin/")

--- a/gem/tests/test_auth.py
+++ b/gem/tests/test_auth.py
@@ -13,7 +13,6 @@ from gem.tests.base import GemTestCaseMixin
 from gem.views import (
     RedirectWithQueryStringView, CustomAuthenticationCallbackView,
     CustomAuthenticationRequestView)
-from gem.utils import get_oidc_settings
 from wagtail.wagtailcore import urls as wagtail_urls
 from wagtail.wagtailadmin import urls as wagtailadmin_urls
 from django.core.urlresolvers import reverse
@@ -263,13 +262,3 @@ class TestOIDCAuthIntegration(TestCase, GemTestCaseMixin):
         self.assertContains(response, "Welcome to the GEM Wagtail CMS")
         # test that the correct logout button is in in the template
         self.assertContains(response, "oidc/logout")
-
-    def test_get_oidc_settings_util(self):
-        OIDCSettings.objects.create(
-            site=self.main.get_site(), oidc_rp_client_secret='secret',
-            oidc_rp_client_id='id',
-            wagtail_redirect_url='https://redirecit.com')
-        request = HttpRequest()
-        request.site = self.main.get_site()
-        settings = get_oidc_settings(request)
-        self.assertEquals(settings.site.pk, self.main.get_site().pk)

--- a/gem/tests/test_auth.py
+++ b/gem/tests/test_auth.py
@@ -13,6 +13,7 @@ from gem.tests.base import GemTestCaseMixin
 from gem.views import (
     RedirectWithQueryStringView, CustomAuthenticationCallbackView,
     CustomAuthenticationRequestView)
+from gem.utils import get_oidc_settings
 from wagtail.wagtailcore import urls as wagtail_urls
 from wagtail.wagtailadmin import urls as wagtailadmin_urls
 from django.core.urlresolvers import reverse
@@ -258,3 +259,13 @@ class TestOIDCAuthIntegration(TestCase, GemTestCaseMixin):
         self.assertContains(response, "Welcome to the GEM Wagtail CMS")
         # test that the correct logout button is in in the template
         self.assertContains(response, "oidc/logout")
+
+    def test_get_oidc_settings_util(self):
+        OIDCSettings.objects.create(
+            site=self.main.get_site(), oidc_rp_client_secret='secret',
+            oidc_rp_client_id='id',
+            wagtail_redirect_url='https://redirecit.com')
+        request = HttpRequest()
+        request.site = self.main.get_site()
+        settings = get_oidc_settings(request)
+        self.assertEquals(settings.site.pk, self.main.get_site().pk)

--- a/gem/utils.py
+++ b/gem/utils.py
@@ -26,12 +26,3 @@ def provider_logout_url(request):
     redirect_url = settings.OIDC_OP_LOGOUT_URL + "?" + urlencode(
         parameters, doseq=True)
     return redirect_url
-
-
-def get_oidc_settings(request):
-    site = request.site
-    if not hasattr(site, "oidcsettings"):
-        raise RuntimeError(
-            "Site {} has no settings configured.".format(site))
-
-    return site.oidcsettings

--- a/gem/utils.py
+++ b/gem/utils.py
@@ -26,3 +26,12 @@ def provider_logout_url(request):
     redirect_url = settings.OIDC_OP_LOGOUT_URL + "?" + urlencode(
         parameters, doseq=True)
     return redirect_url
+
+
+def get_oidc_settings(request):
+    site = request.site
+    if not hasattr(site, "oidcsettings"):
+        raise RuntimeError(
+            "Site {} has no settings configured.".format(site))
+
+    return site.oidcsettings


### PR DESCRIPTION
We need to update the auth service links with the correct parameters dynamically based on the `request.site`.

I'm not sure if this is the best way to do it, we could keep these links in the settings file and use middleware to update it as an alternative? but these values are only called in the templates and bad practice to use middleware to update settings?

Any thoughts? 