### PR TITLE
Add language code to requests to the auth service

### DIFF
--- a/gem/context_processors.py
+++ b/gem/context_processors.py
@@ -40,6 +40,7 @@ def compress_settings(request):
 
     if settings.USE_OIDC_AUTHENTICATION:
         site = request.site
+        language = getattr(request, 'LANGUAGE_CODE', 'en')
         if not hasattr(site, "oidcsettings"):
             raise RuntimeError(
                 "Site {} has no settings configured.".format(site))
@@ -48,21 +49,23 @@ def compress_settings(request):
         if oidc_settings:
             REGISTRATION_URL = (
                 "%s/registration/?theme=%s&hide=end-user&redirect_uri=%s"
-                "&client_id=%s" % (
+                "&client_id=%s&language=%s" % (
                     settings.OIDC_OP, settings.THEME,
                     request.site.root_url
                     + reverse('oidc_authentication_init'),
-                    oidc_settings.oidc_rp_client_id))
+                    oidc_settings.oidc_rp_client_id, language))
             VIEW_PROFILE_URL = (
-                "%s/profile/edit/?theme=%s&redirect_uri=%s&client_id=%s" % (
+                "%s/profile/edit/?theme=%s&redirect_uri=%s&client_id=%s"
+                "&language=%s" % (
                     settings.OIDC_OP, settings.THEME,
                     oidc_settings.wagtail_redirect_url,
-                    oidc_settings.oidc_rp_client_id))
+                    oidc_settings.oidc_rp_client_id, language))
             EDIT_PROFILE_URL = (
-                "%s/profile/edit/?theme=%s&redirect_uri=%s&client_id=%s" % (
+                "%s/profile/edit/?theme=%s&redirect_uri=%s&client_id=%s"
+                "&language=%s" % (
                     settings.OIDC_OP, settings.THEME,
                     oidc_settings.wagtail_redirect_url,
-                    oidc_settings.oidc_rp_client_id))
+                    oidc_settings.oidc_rp_client_id, language))
 
     return {
         'STATIC_URL': settings.STATIC_URL,

--- a/gem/context_processors.py
+++ b/gem/context_processors.py
@@ -40,7 +40,7 @@ def compress_settings(request):
 
     if settings.USE_OIDC_AUTHENTICATION:
         site = request.site
-        language = getattr(request, 'LANGUAGE_CODE', 'en')
+        language = getattr(request, 'LANGUAGE_CODE', settings.LANGUAGE_CODE)
         if not hasattr(site, "oidcsettings"):
             raise RuntimeError(
                 "Site {} has no settings configured.".format(site))

--- a/gem/tests/test_context_processors.py
+++ b/gem/tests/test_context_processors.py
@@ -5,6 +5,8 @@ from gem.context_processors import (
     detect_bbm,
     detect_freebasics,
 )
+from gem.models import OIDCSettings
+from gem.tests.base import GemTestCaseMixin
 
 
 class TestDetectBbm(TestCase):
@@ -61,7 +63,11 @@ class TestDetectFreebasics(TestCase):
         )
 
 
-class TestCompressSettings(TestCase):
+class TestCompressSettings(TestCase, GemTestCaseMixin):
+    def setUp(self):
+        self.main = self.mk_main(
+            title='main1', slug='main1', path='00010002', url_path='/main1/')
+
     @override_settings(ENV='test_env', STATIC_URL='test_static_url')
     def test_returns_settings(self):
         request = RequestFactory().get('/')
@@ -77,3 +83,32 @@ class TestCompressSettings(TestCase):
                 'STATIC_URL': 'test_static_url',
             }
         )
+
+    @override_settings(ENV='test_env', STATIC_URL='test_static_url',
+                       USE_OIDC_AUTHENTICATION='True')
+    def test_returns_oidc_settings(self):
+        request = RequestFactory().get('/')
+        site = self.main.get_site()
+        site.oidcsettings = OIDCSettings.objects.create(
+            oidc_rp_client_id='client_id',
+            oidc_rp_client_secret='client_secret', oidc_rp_scopes='scopes',
+            wagtail_redirect_url='http://example.url', site_id=site.id)
+        request.site = site
+
+        settings = compress_settings(request)
+        self.assertEqual(settings['LOGIN_URL'], 'molo.profiles:auth_login')
+        self.assertEqual(
+            settings['VIEW_PROFILE_URL'],
+            u'/profile/edit/?theme=springster&redirect_uri='
+            'http://example.url&client_id=client_id&language=en')
+        self.assertEqual(settings['EDIT_PROFILE_URL'],
+                         u'/profile/edit/?theme=springster&redirect_uri='
+                         'http://example.url&client_id=client_id&language=en')
+        self.assertEqual(
+            settings['REGISTRATION_URL'],
+            u'/registration/?theme=springster&hide=end-user&redirect_uri='
+            'http://main1-1.localhost/oidc/authenticate/&client_id=client_id&'
+            'language=en')
+        self.assertEqual(settings['LOGOUT_URL'], 'molo.profiles:auth_logout')
+        self.assertEqual(settings['ENV'], 'test_env')
+        self.assertEqual(settings['STATIC_URL'], 'test_static_url')

--- a/gem/tests/test_context_processors.py
+++ b/gem/tests/test_context_processors.py
@@ -87,6 +87,10 @@ class TestCompressSettings(TestCase, GemTestCaseMixin):
     @override_settings(ENV='test_env', STATIC_URL='test_static_url',
                        USE_OIDC_AUTHENTICATION='True')
     def test_returns_oidc_settings(self):
+        """ Test OIDC settings for a site are used when getting the settings
+        for a request
+        """
+        # Create request and add settings to site
         request = RequestFactory().get('/')
         site = self.main.get_site()
         site.oidcsettings = OIDCSettings.objects.create(
@@ -95,6 +99,7 @@ class TestCompressSettings(TestCase, GemTestCaseMixin):
             wagtail_redirect_url='http://example.url', site_id=site.id)
         request.site = site
 
+        # Check settings
         settings = compress_settings(request)
         self.assertEqual(settings['LOGIN_URL'], 'molo.profiles:auth_login')
         self.assertEqual(

--- a/gem/tests/test_views.py
+++ b/gem/tests/test_views.py
@@ -567,6 +567,9 @@ class TestCustomAuthenticationRequestView(TestCase, GemTestCaseMixin):
 
     @patch('mozilla_django_oidc.views.OIDCAuthenticationRequestView.get')
     def test_settings_added_to_login_request(self, mock_super):
+        """ Test the custom auth view adds the neccessary settings to the
+        request
+        """
         view = CustomAuthenticationRequestView()
         request = RequestFactory().get('/')
         site = self.main.get_site()

--- a/gem/tests/test_views.py
+++ b/gem/tests/test_views.py
@@ -576,10 +576,7 @@ class TestCustomAuthenticationRequestView(TestCase, GemTestCaseMixin):
         request.site = site
 
         # Check an error is raised if settings don't exist
-        with self.assertRaises(RuntimeError) as e:
-            view.get(request)
-        self.assertTrue("Site {} has no settings configured.".format(site)
-                        in e.exception)
+        self.assertRaises(RuntimeError, view.get, request)
 
         # Add settings
         site.oidcsettings = OIDCSettings.objects.create(
@@ -601,10 +598,7 @@ class TestCustomAuthenticationRequestView(TestCase, GemTestCaseMixin):
         request.site = site
 
         # Check an error is raised if settings don't exist
-        with self.assertRaises(RuntimeError) as e:
-            view.get_extra_params(request)
-        self.assertTrue("Site {} has no settings configured.".format(site)
-                        in e.exception)
+        self.assertRaises(RuntimeError, view.get_extra_params, request)
 
         # Add settings
         site.oidcsettings = OIDCSettings.objects.create(

--- a/gem/views.py
+++ b/gem/views.py
@@ -107,7 +107,7 @@ class CustomAuthenticationRequestView(OIDCAuthenticationRequestView):
         params = super(
             CustomAuthenticationRequestView, self).get_extra_params(request)
         site = request.site
-        language = getattr(request, 'LANGUAGE_CODE', 'en')
+        language = getattr(request, 'LANGUAGE_CODE', settings.LANGUAGE_CODE)
         if not hasattr(site, "oidcsettings"):
             raise RuntimeError(
                 "Site {} has no settings configured.".format(site))

--- a/gem/views.py
+++ b/gem/views.py
@@ -107,10 +107,11 @@ class CustomAuthenticationRequestView(OIDCAuthenticationRequestView):
         params = super(
             CustomAuthenticationRequestView, self).get_extra_params(request)
         site = request.site
+        language = getattr(request, 'LANGUAGE_CODE', 'en')
         if not hasattr(site, "oidcsettings"):
             raise RuntimeError(
                 "Site {} has no settings configured.".format(site))
-        params.update({'theme': settings.THEME})
+        params.update({'theme': settings.THEME, 'language': language})
         return params
 
 


### PR DESCRIPTION
In order to translate pages on the auth service to the user's preference we need to send their preference through as part of the url.
This adds it for the Login, profile edit, profile view and registration requests