### PR TITLE
downgraded markup to version 2.6.11

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+markdown==2.6.11
 pytest==3.3.1
 pytest-django==3.1.1
 pytest-cov


### PR DESCRIPTION
Docker was installing markup version 3 which was making tests fail