### PR TITLE
Your Words view live calling empty yourwords

### DIFF
--- a/gem/templates/springster/yourwords/your_words_competition.html
+++ b/gem/templates/springster/yourwords/your_words_competition.html
@@ -13,11 +13,11 @@
       </div>
     {% endif %}
     {% if request.user.is_authenticated %}
-      <a href="{% url 'molo.yourwords:competition_entry' competition.slug  %}" class="call-to-action__button call-to-action__button--primary">
+      <a href="{% url 'molo.yourwords:competition_entry' self.slug  %}" class="call-to-action__button call-to-action__button--primary">
         <span class="call-to-action__button-text call-to-action__button-text--primary">{% trans "Enter" %}</span>
       </a>
     {% else %}
-      <a href="{% url LOGIN_URL %}?next={% url 'molo.yourwords:competition_entry' competition.slug %}" class="call-to-action__button call-to-action__button--primary">
+      <a href="{% url LOGIN_URL %}?next={% url 'molo.yourwords:competition_entry' self.slug %}" class="call-to-action__button call-to-action__button--primary">
         <span class="call-to-action__button-text call-to-action__button-text--primary">{% trans "Log in to Enter" %}</span>
       </a>
     {% endif %}


### PR DESCRIPTION
The source of the issue is that YourWords competitions is producing Internal Server errors in Admin via Preview and Live, therefore when selecting the Banner via the front-end the same error occurs
This occurs in both the QA and PROD environments
We require additional DEV to investigate and resolve this defect